### PR TITLE
ci: build before pkg-pr-new publish

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,5 +91,8 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm install
 
+      - name: 🏗️ Build
+        run: pnpm run build
+
       - name: ⚡ Publish prerelease
         run: pnpx pkg-pr-new publish --pnpm --compact


### PR DESCRIPTION
The `build` step for `pkg-pr-new` continuous release workflow was deleted incorrectly in https://github.com/rolldown/tsdown/pull/105. This causes the published package (e.g. `npm i https://pkg.pr.new/tsdown@6c954c5`) not contains `dist/`. 