### PR TITLE
fix: zh-cn config-options outline level

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -110,6 +110,7 @@ export function getLocaleConfig(lang: string) {
     Object.assign(themeConfig, {
       outline: {
         label: '页面导航',
+        level: 'deep'
       },
       lastUpdatedText: '最后更新于',
       darkModeSwitchLabel: '外观',


### PR DESCRIPTION
Adjusted the right-side navigation in the Chinese documentation to enable quick anchor point jumps. @sxzz 