### PR TITLE
docs: show the corresponding SVG for the `VoidZero` in dark/light mode

### DIFF
--- a/docs/.vitepress/components/HomePage.vue
+++ b/docs/.vitepress/components/HomePage.vue
@@ -38,7 +38,8 @@ const { lang } = useData()
 }
 
 .voidzero {
-  background: url(https://voidzero.dev/logo.svg) no-repeat center / auto 75px;
+  background: url(https://voidzero.dev/logo.svg) no-repeat center;
+  background-size: contain;
 }
 
 .dark .voidzero {

--- a/docs/.vitepress/components/HomePage.vue
+++ b/docs/.vitepress/components/HomePage.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts">
 import { useData } from 'vitepress'
-import { computed } from 'vue'
 
-const { lang, isDark } = useData()
-
-const voidZeroLogo = computed(() =>
-  isDark
-    ? 'https://voidzero.dev/logo-white.svg'
-    : 'https://voidzero.dev/logo.svg',
-)
+const { lang } = useData()
 </script>
 
 <template>
   <div flex="~ col" items-center justify-center>
     <div mt20 flex="~ col" items-center gap8>
       <h2 v-if="lang === 'en'" class="voidzero-title">Brought to you by</h2>
-      <a href="https://voidzero.dev/" target="_blank" title="voidzero.dev">
-        <img :src="voidZeroLogo" alt="VoidZero" h-75px w-300px />
-      </a>
+      <a
+        class="voidzero"
+        href="https://voidzero.dev/"
+        target="_blank"
+        title="voidzero.dev"
+        alt="VoidZero"
+        block
+        h-75px
+        w-300px
+      />
       <h2 v-if="lang === 'zh-CN'" class="voidzero-title">
         由 VoidZero 隆重推出
       </h2>
@@ -35,5 +35,13 @@ const voidZeroLogo = computed(() =>
   line-height: 32px;
   font-size: 24px;
   font-weight: 600;
+}
+
+.voidzero {
+  background: url(https://voidzero.dev/logo.svg) no-repeat center / auto 75px;
+}
+
+.dark .voidzero {
+  background-image: url(https://voidzero.dev/logo-white.svg);
 }
 </style>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
The VoidZero logo is not shown correctly in light mode but in dark mode.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR:
• removed the computed ‎`voidZeroLogo` logic from the Vue component.
• replaced the ‎`<img>` tag with a styled ‎`<a>` element using a ‎`.voidzero` class.
• added CSS rules to apply the correct background image for both light and dark themes.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
