### PR TITLE
docs: add tsdown icon

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     groupIconVitePlugin({
       customIcon: {
         rolldown: localIconLoader(import.meta.url, 'public/lightning-down.svg'),
+        tsdown: localIconLoader(import.meta.url, 'public/tsdown.svg'),
       },
     }),
     llmstxt({


### PR DESCRIPTION
### Description

I think it would be nice if `tsdown.config.ts` file have a special icon.

<img width="541" alt="image" src="https://github.com/user-attachments/assets/00a4cf27-8929-47e8-bf7e-2460a6d635d1" />


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
