### PR TITLE
fix: watch mode outDir cannot be an empty string

### DIFF
--- a/src/features/watch.ts
+++ b/src/features/watch.ts
@@ -12,18 +12,21 @@ export async function watchBuild(
   rebuild: () => void,
   restart: () => void,
 ): Promise<FSWatcher> {
-  const root = process.cwd()
-  if (options.outDir === root) {
-    throw new Error(
-      'options.outDir cannot be an empty string, which will cause the watch to be invalid.',
-    )
-  }
   const { watch } = await import('chokidar')
   const debouncedRebuild = debounce(rebuild, 100)
 
+  const cwd = process.cwd()
+  if (typeof options.watch === 'boolean' && options.outDir === cwd) {
+    throw new Error(
+      `Watch is enabled, but output directory is the same as the current working directory.` +
+        `Please specify a different watch directory using \`watch\` option,` +
+        `or set \`outDir\` to a different directory.`,
+    )
+  }
   const files = toArray(
-    typeof options.watch === 'boolean' ? root : options.watch,
+    typeof options.watch === 'boolean' ? cwd : options.watch,
   )
+
   logger.info(`Watching for changes in ${files.join(', ')}`)
   if (configFile) files.push(configFile)
 

--- a/src/features/watch.ts
+++ b/src/features/watch.ts
@@ -12,11 +12,17 @@ export async function watchBuild(
   rebuild: () => void,
   restart: () => void,
 ): Promise<FSWatcher> {
+  const root = process.cwd()
+  if (options.outDir === root) {
+    throw new Error(
+      'options.outDir cannot be an empty string, which will cause the watch to be invalid.',
+    )
+  }
   const { watch } = await import('chokidar')
   const debouncedRebuild = debounce(rebuild, 100)
 
   const files = toArray(
-    typeof options.watch === 'boolean' ? process.cwd() : options.watch,
+    typeof options.watch === 'boolean' ? root : options.watch,
   )
   logger.info(`Watching for changes in ${files.join(', ')}`)
   if (configFile) files.push(configFile)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When `outDir` is an empty string, the project root directory is added to the ignored list, which will invalidate the watch.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
