### PR TITLE
feat: add support for declaration maps

### DIFF
--- a/docs/guide/dts.md
+++ b/docs/guide/dts.md
@@ -60,4 +60,27 @@ If `isolatedDeclarations` is not enabled, `tsdown` will fall back to using the T
 
 ## Advanced Options
 
+### Declaration Maps
+
+Declaration maps allow developers to navigate directly to the original TypeScript source files when using "Go to Definition" on types from your library. This makes debugging and exploring external libraries much more convenient.
+
+To enable declaration maps, set the `declarationMap` option in your config:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  dts: {
+    declarationMap: true,
+  },
+})
+```
+
+When enabled, `.d.ts.map` files will be generated alongside your declaration files.
+
+> [!NOTE]
+> Declaration maps are only available when using the TypeScript compiler for declaration generation (not in `isolatedDeclarations` mode).
+
+### Plugin Options
+
 `rolldown-plugin-dts` provides several advanced options to customize `.d.ts` generation. For a detailed explanation of these options, refer to the [plugin's documentation](https://github.com/sxzz/rolldown-plugin-dts#options).

--- a/docs/zh-CN/guide/dts.md
+++ b/docs/zh-CN/guide/dts.md
@@ -60,4 +60,27 @@ export default defineConfig({
 
 ## 高级选项
 
-`rolldown-plugin-dts` 提供了多个高级选项，用于自定义 `.d.ts` 文件的生成。有关这些选项的详细说明，请参阅 [插件文档](https://github.com/sxzz/rolldown-plugin-dts#options)。
+### 声明文件映射
+
+声明文件映射（Declaration Maps）允许开发者在使用库中的类型进行"转到定义"导航时，直接跳转到原始的 TypeScript 源文件。这使得调试和探索外部库变得更加方便。
+
+要启用声明文件映射，请在配置中设置 `declarationMap` 选项：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  dts: {
+    declarationMap: true,
+  },
+})
+```
+
+启用后，系统将在声明文件旁边生成 `.d.ts.map` 文件。
+
+> [!NOTE]
+> 声明文件映射仅在使用 TypeScript 编译器进行声明生成时可用（不适用于 `isolatedDeclarations` 模式）。
+
+### 插件选项
+
+`rolldown-plugin-dts` 提供了多个高级选项，用于自定义 `.d.ts` 文件的生成。有关这些选项的详细说明，请参阅 [插件文档](https://github.com/sxzz/rolldown-plugin-dts#options).

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,17 @@ async function getBuildOptions(
 
   if (dts) {
     const { dts: dtsPlugin } = await import('rolldown-plugin-dts')
-    const options: DtsOptions = { tsconfig, ...dts }
+    const { declarationMap, ...dtsOptions } = dts as DtsOptions & {
+      declarationMap?: boolean
+    }
+    const options: DtsOptions = {
+      tsconfig,
+      ...dtsOptions,
+      compilerOptions: {
+        ...dtsOptions.compilerOptions,
+        ...(declarationMap ? { declarationMap: true } : {}),
+      },
+    }
 
     if (format === 'es') {
       plugins.push(dtsPlugin(options))

--- a/src/options.ts
+++ b/src/options.ts
@@ -132,7 +132,7 @@ export interface Options {
   /**
    * Emit declaration files
    */
-  dts?: boolean | DtsOptions
+  dts?: boolean | (DtsOptions & { declarationMap?: boolean })
 
   /**
    * Enable unused dependencies check with `unplugin-unused`


### PR DESCRIPTION
### Description

The implementation:
1. Extends the `dts` option to support a `declarationMap` boolean flag
2. Passes this flag to the TypeScript compiler via the plugin options

When enabled through the configuration, `.d.ts.map` files will be generated alongside declaration files.

### Linked Issues

Fixes #148

### Additional context

Declaration maps are only available when using the TypeScript compiler for declaration generation (not in `isolatedDeclarations` mode).

Usage example:
```ts
// tsdown.config.ts
import { defineConfig } from 'tsdown'

export default defineConfig({
  dts: {
    declarationMap: true
  }
})