### PR TITLE
fix: wire up publint options

### DIFF
--- a/src/features/publint.ts
+++ b/src/features/publint.ts
@@ -2,14 +2,15 @@ import process from 'node:process'
 import Debug from 'debug'
 import { logger } from '../utils/logger'
 import type { PackageJson } from 'pkg-types'
+import type { Options as PublintOptions } from 'publint'
 
 const debug = Debug('tsdown:publint')
 
-export async function publint(pkg: PackageJson): Promise<void> {
+export async function publint(pkg: PackageJson, options: PublintOptions): Promise<void> {
   debug('Running publint')
   const { publint } = await import('publint')
   const { formatMessage } = await import('publint/utils')
-  const { messages } = await publint()
+  const { messages } = await publint(options)
   debug('Found %d issues', messages.length)
 
   if (!messages.length) {

--- a/src/features/publint.ts
+++ b/src/features/publint.ts
@@ -6,7 +6,10 @@ import type { Options as PublintOptions } from 'publint'
 
 const debug = Debug('tsdown:publint')
 
-export async function publint(pkg: PackageJson, options: PublintOptions): Promise<void> {
+export async function publint(
+  pkg: PackageJson,
+  options: PublintOptions,
+): Promise<void> {
   debug('Running publint')
   const { publint } = await import('publint')
   const { formatMessage } = await import('publint/utils')

--- a/src/features/publint.ts
+++ b/src/features/publint.ts
@@ -2,13 +2,13 @@ import process from 'node:process'
 import Debug from 'debug'
 import { logger } from '../utils/logger'
 import type { PackageJson } from 'pkg-types'
-import type { Options as PublintOptions } from 'publint'
+import type { Options } from 'publint'
 
 const debug = Debug('tsdown:publint')
 
 export async function publint(
   pkg: PackageJson,
-  options: PublintOptions,
+  options?: Options,
 ): Promise<void> {
   debug('Running publint')
   const { publint } = await import('publint')

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   type OutputOptions,
   type RolldownPluginOption,
 } from 'rolldown'
+import type { Options as PublintOptions } from 'publint'
 import { transformPlugin } from 'rolldown/experimental'
 import { exec } from 'tinyexec'
 import { cleanOutDir } from './features/clean'
@@ -153,7 +154,7 @@ export async function buildSingle(
 
     if (config.publint) {
       if (config.pkg) {
-        await publint(config.pkg)
+        await publint(config.pkg, config.publint as PublintOptions)
       } else {
         logger.warn('publint is enabled but package.json is not found')
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import {
   type OutputOptions,
   type RolldownPluginOption,
 } from 'rolldown'
-import type { Options as PublintOptions } from 'publint'
 import { transformPlugin } from 'rolldown/experimental'
 import { exec } from 'tinyexec'
 import { cleanOutDir } from './features/clean'
@@ -32,6 +31,7 @@ import {
 import { ShebangPlugin } from './plugins'
 import { logger, setSilent } from './utils/logger'
 import { prettyFormat } from './utils/package'
+import type { Options as PublintOptions } from 'publint'
 import type { Options as DtsOptions } from 'rolldown-plugin-dts'
 
 const debug = Debug('tsdown:main')

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ import {
 import { ShebangPlugin } from './plugins'
 import { logger, setSilent } from './utils/logger'
 import { prettyFormat } from './utils/package'
-import type { Options as PublintOptions } from 'publint'
 import type { Options as DtsOptions } from 'rolldown-plugin-dts'
 
 const debug = Debug('tsdown:main')
@@ -154,7 +153,7 @@ export async function buildSingle(
 
     if (config.publint) {
       if (config.pkg) {
-        await publint(config.pkg, config.publint as PublintOptions)
+        await publint(config.pkg, config.publint === true ? {} : config.publint)
       } else {
         logger.warn('publint is enabled but package.json is not found')
       }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I found some issues in `ota-meshi/typescript-eslint-parser-for-extra-files`'s dts output, so I'm migrating it to tsdown.
It uses Yarn@1 ☹️ so I tried to pass `{ pack: "npm" }` to the publint parameter, but it didn't work.
This wires it up.

### Linked Issues


### Additional context

I wrote #168 in trying to write a repro for it. :)

Didn't see any existing tests, so I didn't add any new ones.
