### PR TITLE
feat(node-protocol): add option to remove the `node:` protocol

### DIFF
--- a/src/features/node-protocol.ts
+++ b/src/features/node-protocol.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from 'rolldown'
 
 /**
- * The node: protocol was added to require in Node v14.18.0
- * https://nodejs.org/api/esm.html#node-imports
+ * The `node:` protocol was added in Node.js v14.18.0.
+ * @see https://nodejs.org/api/esm.html#node-imports
  */
-export const nodeProtocolPlugin = (): Plugin => {
+export const NodeProtocolPlugin = (): Plugin => {
   return {
-    name: 'node-protocol-plugin',
+    name: 'tsdown:node-protocol',
     transform(code) {
       let transformedCode = code.replaceAll(
         /from\s+['"]node:([^'"]+)['"]/g,

--- a/src/features/node-protocol.ts
+++ b/src/features/node-protocol.ts
@@ -4,19 +4,17 @@ import type { Plugin } from 'rolldown'
  * The `node:` protocol was added in Node.js v14.18.0.
  * @see https://nodejs.org/api/esm.html#node-imports
  */
-export const NodeProtocolPlugin = (): Plugin => {
+export function NodeProtocolPlugin(): Plugin {
   return {
     name: 'tsdown:node-protocol',
-    transform(code) {
-      let transformedCode = code.replaceAll(
-        /from\s+['"]node:([^'"]+)['"]/g,
-        'from "$1"',
-      )
-      transformedCode = transformedCode.replaceAll(
-        /require\(['"]node:([^'"]+)['"]\)/g,
-        'require("$1")',
-      )
-      return transformedCode === code ? null : transformedCode
+    resolveId(id) {
+      if (id.startsWith('node:')) {
+        return {
+          id: id.slice(5),
+          external: true,
+          moduleSideEffects: false,
+        }
+      }
     },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { cleanOutDir } from './features/clean'
 import { ExternalPlugin } from './features/external'
 import { createHooks } from './features/hooks'
 import { LightningCSSPlugin } from './features/lightningcss'
+import { NodeProtocolPlugin } from './features/node-protocol'
 import { resolveChunkFilename } from './features/output'
 import { publint } from './features/publint'
 import { ReportPlugin } from './features/report'
@@ -28,7 +29,6 @@ import {
   type Options,
   type ResolvedOptions,
 } from './options'
-import { nodeProtocolPlugin } from './plugin/node-protocol'
 import { ShebangPlugin } from './plugins'
 import { logger, setSilent } from './utils/logger'
 import { prettyFormat } from './utils/package'
@@ -256,7 +256,7 @@ async function getBuildOptions(
   plugins.push(userPlugins)
 
   if (removeNodeProtocol) {
-    plugins.push(nodeProtocolPlugin())
+    plugins.push(NodeProtocolPlugin())
   }
 
   const inputOptions = await mergeUserOptions(

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   type Options,
   type ResolvedOptions,
 } from './options'
+import { nodeProtocolPlugin } from './plugin/node-protocol'
 import { ShebangPlugin } from './plugins'
 import { logger, setSilent } from './utils/logger'
 import { prettyFormat } from './utils/package'
@@ -203,6 +204,7 @@ async function getBuildOptions(
     cwd,
     report,
     env,
+    removeNodeProtocol,
   } = config
 
   const plugins: RolldownPluginOption = []
@@ -252,6 +254,10 @@ async function getBuildOptions(
   }
 
   plugins.push(userPlugins)
+
+  if (removeNodeProtocol) {
+    plugins.push(nodeProtocolPlugin())
+  }
 
   const inputOptions = await mergeUserOptions(
     {

--- a/src/options.ts
+++ b/src/options.ts
@@ -178,12 +178,13 @@ export interface Options {
     | ((hooks: Hookable<TsdownHooks>) => Awaitable<void>)
 
   /**
-   * Remove `node:` protocol from import specifiers.
+   * If enabled, strips the `node:` protocol prefix from import source.
+   *
    * @default false
+   *
    * @example
-   * ```ts
-   * import('node:fs')
-   * // => import('fs')
+   * // With removeNodeProtocol enabled:
+   * import('node:fs'); // becomes import('fs')
    */
   removeNodeProtocol?: boolean
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -176,6 +176,16 @@ export interface Options {
   hooks?:
     | Partial<TsdownHooks>
     | ((hooks: Hookable<TsdownHooks>) => Awaitable<void>)
+
+  /**
+   * Remove `node:` protocol from import specifiers.
+   * @default false
+   * @example
+   * ```ts
+   * import('node:fs')
+   * // => import('fs')
+   */
+  removeNodeProtocol?: boolean
 }
 
 /**
@@ -201,6 +211,7 @@ export type ResolvedOptions = Omit<
       | 'fixedExtension'
       | 'outExtensions'
       | 'hooks'
+      | 'removeNodeProtocol'
     >,
     {
       format: NormalizedFormat[]

--- a/src/plugin/node-protocol.ts
+++ b/src/plugin/node-protocol.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'rolldown'
+
+/**
+ * The node: protocol was added to require in Node v14.18.0
+ * https://nodejs.org/api/esm.html#node-imports
+ */
+export const nodeProtocolPlugin = (): Plugin => {
+  return {
+    name: 'node-protocol-plugin',
+    transform(code) {
+      let transformedCode = code.replaceAll(
+        /from\s+['"]node:([^'"]+)['"]/g,
+        'from "$1"',
+      )
+      transformedCode = transformedCode.replaceAll(
+        /require\(['"]node:([^'"]+)['"]\)/g,
+        'require("$1")',
+      )
+      return transformedCode === code ? null : transformedCode
+    },
+  }
+}

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,3 +1,4 @@
 export { ExternalPlugin } from './features/external'
 export { ShebangPlugin } from './features/shebang'
 export { ReportPlugin } from './features/report'
+export { NodeProtocolPlugin } from './features/node-protocol'

--- a/tests/__snapshots__/remove-node-protocol.snap.md
+++ b/tests/__snapshots__/remove-node-protocol.snap.md
@@ -1,0 +1,12 @@
+## index.js
+
+```js
+import fs from "fs";
+import { join } from "path";
+
+//#region index.ts
+const promise = import("fs/promises");
+
+//#endregion
+export { fs, join, promise };
+```

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -270,3 +270,19 @@ test('iife and umd', async (context) => {
     ]
   `)
 })
+
+test('remove node protocol', async (context) => {
+  const files = {
+    'index.ts': `
+    import fs from 'node:fs'
+    import { join } from 'node:path'
+    const promise = import('node:fs/promises')
+
+    export { fs, join, promise }
+    `,
+  }
+  const { snapshot } = await testBuild(context, files, {
+    removeNodeProtocol: true,
+  })
+  expect(snapshot).not.contains('node:')
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
fix:https://github.com/rolldown/tsdown/issues/176

@sxzz the script needs to update the document,，
In addition, I created a new plugins file, and I'm going to move it to plugins in the next pr, which will be clearer. What do you think?
<img width="542" alt="image" src="https://github.com/user-attachments/assets/8c206d52-24b8-445d-934b-0d2ea5d2bbff" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
