### PR TITLE
add support fo copying static folders

### DIFF
--- a/src/features/pubdir.ts
+++ b/src/features/pubdir.ts
@@ -1,0 +1,22 @@
+import path from "node:path"
+import { copyDirSync } from "../utils/fs"
+import { slash } from "../utils/general"
+
+export const copyPubDir = (
+  publicDir: string | boolean | undefined,
+  outDir: string
+): void => {
+  if (!publicDir) return
+  copyDirSync(path.resolve(publicDir === true ? "public" : publicDir), outDir)
+}
+
+export const isInPublicDir = (
+  publicDir: string | boolean | undefined,
+  filePath: string
+): boolean => {
+  if (!publicDir) return false
+  const publicPath = slash(
+    path.resolve(publicDir === true ? 'public' : publicDir),
+  )
+  return slash(path.resolve(filePath)).startsWith(`${publicPath}/`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   type Options,
   type ResolvedOptions,
 } from './options'
+import { copyPubDir, isInPublicDir } from './features/pubdir'
 import { ShebangPlugin } from './plugins'
 import { logger, setSilent } from './utils/logger'
 import { prettyFormat } from './utils/package'

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,6 +1,6 @@
 import { access, rm } from 'node:fs/promises'
-import { dirname, normalize, sep } from 'node:path'
-
+import path, { dirname, normalize, sep } from 'node:path'
+import fs from 'node:fs'
 export function fsExists(path: string): Promise<boolean> {
   return access(path).then(
     () => true,
@@ -9,7 +9,7 @@ export function fsExists(path: string): Promise<boolean> {
 }
 
 export function fsRemove(path: string): Promise<void> {
-  return rm(path, { force: true, recursive: true }).catch(() => {})
+  return rm(path, { force: true, recursive: true }).catch(() => { })
 }
 
 export function lowestCommonAncestor(...filepaths: string[]): string {
@@ -35,4 +35,24 @@ export function lowestCommonAncestor(...filepaths: string[]): string {
   return ancestor.length <= 1 && ancestor[0] === ''
     ? sep + ancestor[0]
     : ancestor.join(sep)
+}
+
+export function copyDirSync(sourceDir: string, destDir: string): void {
+  if (!fs.existsSync(sourceDir)) return
+
+  fs.mkdirSync(destDir, { recursive: true })
+
+  for (const file of fs.readdirSync(sourceDir)) {
+    const sourceFile = path.resolve(sourceDir, file)
+    if (sourceFile === destDir) {
+      continue
+    }
+    const destFile = path.resolve(destDir, file)
+    const stat = fs.statSync(sourceFile)
+    if (stat.isDirectory()) {
+      copyDirSync(sourceFile, destFile)
+    } else {
+      fs.copyFileSync(sourceFile, destFile)
+    }
+  }
 }

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -11,6 +11,14 @@ export function toArray<T>(
     return [val]
   }
 }
+export function slash(path: string): string {
+  const isExtendedLengthPath = path.startsWith('\\\\?\\')
+
+  if (isExtendedLengthPath) {
+    return path
+  }
+  return path.replace(/\\/g, '/')
+}
 
 export function resolveComma<T extends string>(arr: T[]): T[] {
   return arr.flatMap((format) => format.split(',') as T[])


### PR DESCRIPTION
### Description
There is no support for copying static folders So this PR trying to add support fo copying static folder and try to implement this format of API 
```typescript
import { defineConfig } from 'tsdown';

export default defineConfig({
	publicDir: [
		'./src/assets/',
		'./src/static/'
	]
});

// OR

export default defineConfig({
	publicDir: {
		'./src/assets/': './dist/assets/',
		'./src/static/': ({ output }) => `${output}/static/`
	}
});
```

### Linked Issues
#160 
### Additional context
N/A yet
