### PR TITLE
fix: `semver/ranges/min-version` module not found

### DIFF
--- a/src/features/target.ts
+++ b/src/features/target.ts
@@ -1,4 +1,4 @@
-import minVersion from 'semver/ranges/min-version'
+import minVersion from 'semver/ranges/min-version.js'
 import { resolveComma, toArray } from '../utils/general'
 import type { PackageJson } from 'pkg-types'
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When I package with tsdown `v0.11.0-beta.1`, I get the following error:
```bash
➜  tsdown-test pnpm tsdown
ℹ tsdown v0.11.0-beta.1 powered by rolldown v1.0.0-beta.8-commit.852c603

  ERROR  Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/tsdown-test/node_modules/.pnpm/tsdown@0.11.0-beta.1_typescript@5.8.3/node_modules/semver/ranges/min-version' imported from /Users/tsdown-test/node_modules/.pnpm/tsdown@0.11.0-beta.1_typescript@5.8.3/node_modules/tsdown/dist/index.js
Did you mean to import "semver/ranges/min-version.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:860:10)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:719:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:643:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:626:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:279:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:136:49) {
  code: 'ERR_MODULE_NOT_FOUND',
```

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
