### PR TITLE
fix: outDir cannot be an empty string

### DIFF
--- a/src/features/clean.ts
+++ b/src/features/clean.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import Debug from 'debug'
 import { glob } from 'tinyglobby'
 import { fsRemove } from '../utils/fs'
@@ -43,11 +44,19 @@ export async function cleanOutDir(configs: ResolvedOptions[]): Promise<void> {
 export function resolveClean(
   clean: Options['clean'],
   outDir: string,
+  cwd: string,
 ): string[] {
   if (clean === true) {
     clean = [slash(outDir)]
   } else if (!clean) {
     clean = []
   }
+
+  if (clean.some((item) => path.resolve(item) === cwd)) {
+    throw new Error(
+      'Cannot clean the current working directory. Please specify a different path to clean option.',
+    )
+  }
+
   return clean
 }

--- a/src/features/watch.ts
+++ b/src/features/watch.ts
@@ -1,4 +1,4 @@
-import process from 'node:process'
+import { blue } from 'ansis'
 import { debounce, toArray } from '../utils/general'
 import { logger } from '../utils/logger'
 import type { ResolvedOptions } from '../options'
@@ -12,9 +12,16 @@ export async function watchBuild(
   rebuild: () => void,
   restart: () => void,
 ): Promise<FSWatcher> {
-  const cwd = process.cwd()
+  if (typeof options.watch === 'boolean' && options.outDir === options.cwd) {
+    throw new Error(
+      `Watch is enabled, but output directory is the same as the current working directory.` +
+        `Please specify a different watch directory using ${blue`watch`} option,` +
+        `or set ${blue`outDir`} to a different directory.`,
+    )
+  }
+
   const files = toArray(
-    typeof options.watch === 'boolean' ? cwd : options.watch,
+    typeof options.watch === 'boolean' ? options.cwd : options.watch,
   )
   logger.info(`Watching for changes in ${files.join(', ')}`)
   if (configFile) files.push(configFile)

--- a/src/features/watch.ts
+++ b/src/features/watch.ts
@@ -1,5 +1,4 @@
 import process from 'node:process'
-import { blue } from 'ansis'
 import { debounce, toArray } from '../utils/general'
 import { logger } from '../utils/logger'
 import type { ResolvedOptions } from '../options'
@@ -14,13 +13,6 @@ export async function watchBuild(
   restart: () => void,
 ): Promise<FSWatcher> {
   const cwd = process.cwd()
-  if (typeof options.watch === 'boolean' && options.outDir === cwd) {
-    throw new Error(
-      `Watch is enabled, but output directory is the same as the current working directory.` +
-        `Please specify a different watch directory using ${blue`watch`} option,` +
-        `or set ${blue`outDir`} to a different directory.`,
-    )
-  }
   const files = toArray(
     typeof options.watch === 'boolean' ? cwd : options.watch,
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { blue, green } from 'ansis'
+import { green } from 'ansis'
 import Debug from 'debug'
 import {
   build as rolldownBuild,
@@ -54,16 +54,6 @@ export async function build(userOptions: Options = {}): Promise<void> {
     })
   } else {
     debug('No config file found')
-  }
-
-  for (const config of configs) {
-    if (config.outDir === process.cwd()) {
-      throw new Error(
-        'Output directory cannot be the same as the current working directory. ' +
-          `Please specify a different watch directory using ${blue`watch`} option,` +
-          `or set ${blue`outDir`} to a different directory.`,
-      )
-    }
   }
 
   let cleanPromise: Promise<void> | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { green } from 'ansis'
+import { blue, green } from 'ansis'
 import Debug from 'debug'
 import {
   build as rolldownBuild,
@@ -54,6 +54,16 @@ export async function build(userOptions: Options = {}): Promise<void> {
     })
   } else {
     debug('No config file found')
+  }
+
+  for (const config of configs) {
+    if (config.outDir === process.cwd()) {
+      throw new Error(
+        'Output directory cannot be the same as the current working directory. ' +
+          `Please specify a different watch directory using ${blue`watch`} option,` +
+          `or set ${blue`outDir`} to a different directory.`,
+      )
+    }
   }
 
   let cleanPromise: Promise<void> | undefined

--- a/src/options.ts
+++ b/src/options.ts
@@ -321,16 +321,23 @@ export async function resolveOptions(options: Options): Promise<{
       } = subOptions
 
       outDir = path.resolve(outDir)
-      if (outDir === process.cwd()) {
+      entry = await resolveEntry(entry, cwd)
+      clean = resolveClean(clean, outDir)
+      if (outDir === process.cwd() && (clean.length || watch)) {
+        let msg = ''
+        if (clean.length && watch) {
+          msg = 'Watch and clean are enabled, '
+        } else if (clean.length) {
+          msg = 'Clean is enabled, '
+        } else {
+          msg = 'Watch is enabled, '
+        }
         throw new Error(
-          'Output directory cannot be the same as the current working directory. ' +
+          `${msg}but output directory cannot be the same as the current working directory. ` +
             `Please specify a different watch directory using ${blue`watch`} option,` +
             `or set ${blue`outDir`} to a different directory.`,
         )
       }
-      entry = await resolveEntry(entry, cwd)
-      clean = resolveClean(clean, outDir)
-
       const pkg = await readPackageJson(cwd)
 
       if (dts == null) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -321,25 +321,27 @@ export async function resolveOptions(options: Options): Promise<{
       } = subOptions
 
       outDir = path.resolve(outDir)
-      entry = await resolveEntry(entry, cwd)
-      clean = resolveClean(clean, outDir)
-      if (outDir === process.cwd() && (clean.length || watch)) {
-        let msg = ''
-        if (clean.length && watch) {
-          msg = 'Watch and clean are enabled, '
-        } else if (clean.length) {
-          msg = 'Clean is enabled, '
-        } else {
-          msg = 'Watch is enabled, '
-        }
-        throw new Error(
-          `${msg}but output directory cannot be the same as the current working directory. ` +
-            `Please specify a different watch directory using ${blue`watch`} option,` +
-            `or set ${blue`outDir`} to a different directory.`,
-        )
-      }
-      const pkg = await readPackageJson(cwd)
+      clean = resolveClean(clean, outDir, cwd)
 
+      if (outDir === process.cwd() && (clean.length || watch)) {
+        // let subject = ''
+        // if (clean.length && watch) {
+        //   subject = 'Watch and clean options are'
+        // } else if (clean.length) {
+        //   subject = 'Clean option is'
+        // } else {
+        //   subject = 'Watch option is'
+        // }
+        // throw new Error(
+        //   `Output directory cannot be the same as the current working directory, ` +
+        //     "if you' using clean or watch options" +
+        //     `Please specify a different watch directory using ${blue`watch`} option,` +
+        //     `or set ${blue`outDir`} to a different directory.`,
+        // )
+      }
+
+      const pkg = await readPackageJson(cwd)
+      entry = await resolveEntry(entry, cwd)
       if (dts == null) {
         dts = !!(pkg?.types || pkg?.typings)
       }

--- a/src/options.ts
+++ b/src/options.ts
@@ -321,6 +321,13 @@ export async function resolveOptions(options: Options): Promise<{
       } = subOptions
 
       outDir = path.resolve(outDir)
+      if (outDir === process.cwd()) {
+        throw new Error(
+          'Output directory cannot be the same as the current working directory. ' +
+            `Please specify a different watch directory using ${blue`watch`} option,` +
+            `or set ${blue`outDir`} to a different directory.`,
+        )
+      }
       entry = await resolveEntry(entry, cwd)
       clean = resolveClean(clean, outDir)
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -323,23 +323,6 @@ export async function resolveOptions(options: Options): Promise<{
       outDir = path.resolve(outDir)
       clean = resolveClean(clean, outDir, cwd)
 
-      if (outDir === process.cwd() && (clean.length || watch)) {
-        // let subject = ''
-        // if (clean.length && watch) {
-        //   subject = 'Watch and clean options are'
-        // } else if (clean.length) {
-        //   subject = 'Clean option is'
-        // } else {
-        //   subject = 'Watch option is'
-        // }
-        // throw new Error(
-        //   `Output directory cannot be the same as the current working directory, ` +
-        //     "if you' using clean or watch options" +
-        //     `Please specify a different watch directory using ${blue`watch`} option,` +
-        //     `or set ${blue`outDir`} to a different directory.`,
-        // )
-      }
-
       const pkg = await readPackageJson(cwd)
       entry = await resolveEntry(entry, cwd)
       if (dts == null) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
If outDir is an empty string, the current logic will clear all files in the root directory of the current project, resulting in a build error.
https://github.com/rolldown/tsdown/blob/3630a61e7c961370b46d71861fceb2f0ea704b4d/src/index.ts#L64-L66
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
