### PR TITLE
fix: `clean: true` not work in Windows

### DIFF
--- a/src/features/clean.ts
+++ b/src/features/clean.ts
@@ -1,6 +1,7 @@
 import Debug from 'debug'
 import { glob } from 'tinyglobby'
 import { fsRemove } from '../utils/fs'
+import { slash } from '../utils/general'
 import { logger } from '../utils/logger'
 import type { Options, ResolvedOptions } from '../options'
 
@@ -44,7 +45,7 @@ export function resolveClean(
   outDir: string,
 ): string[] {
   if (clean === true) {
-    clean = [outDir]
+    clean = [slash(outDir)]
   } else if (!clean) {
     clean = []
   }

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -30,4 +30,8 @@ export function debounce<T extends (...args: any[]) => any>(
   } as T
 }
 
+export function slash(string: string): string {
+  return string.replaceAll('\\', '/')
+}
+
 export const noop = <T>(v: T): T => v


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When `clean` is the default (`true`), it will be assigned with `dist`, whereas in the current behavior, `dist` is resolved to an absolute path before it is assigned to `clean`, and the `glob` is set to `cwd` in `cleanOutDir`, which results in the `glob` getting an empty list of paths, leading to no files being cleaned.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
