### PR TITLE
fix `entry` path to resolve related to build config 

### DIFF
--- a/src/features/entry.ts
+++ b/src/features/entry.ts
@@ -35,7 +35,9 @@ export async function toObjectEntry(
   }
 
   const resolvedEntry = await glob(entry, { cwd })
-  const base = lowestCommonAncestor(...resolvedEntry)
+
+  const absolutePaths = resolvedEntry.map(file => path.isAbsolute(file) ? file : path.resolve(cwd, file))
+  const base = lowestCommonAncestor(...absolutePaths)
   return Object.fromEntries(
     resolvedEntry.map((file) => {
       const relative = path.relative(base, file)


### PR DESCRIPTION

### Description
In `tsdown`, the entry path is resolved relative to the build config. This PR tries to the `entry` parameter to be resolved relative to the root of my package 
### Linked Issues
#198 
### Additional context
Also I can help add  `auto-entry` in this PR or another one 
