### PR TITLE
feat: upgrade rolldown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ catalogs:
       specifier: ^5.5.3
       version: 5.5.3
     rolldown:
-      specifier: 1.0.0-beta.8-commit.05b3e10
-      version: 1.0.0-beta.8-commit.05b3e10
+      specifier: 1.0.0-beta.8-commit.2a5c6a6
+      version: 1.0.0-beta.8-commit.2a5c6a6
     rolldown-plugin-dts:
       specifier: ^0.11.4
       version: 0.11.4
@@ -159,10 +159,10 @@ importers:
         version: 5.5.3
       rolldown:
         specifier: catalog:prod
-        version: 1.0.0-beta.8-commit.05b3e10
+        version: 1.0.0-beta.8-commit.2a5c6a6
       rolldown-plugin-dts:
         specifier: catalog:prod
-        version: 0.11.4(rolldown@1.0.0-beta.8-commit.05b3e10)(typescript@5.8.3)
+        version: 0.11.4(rolldown@1.0.0-beta.8-commit.2a5c6a6)(typescript@5.8.3)
       semver:
         specifier: catalog:prod
         version: 7.7.1
@@ -187,7 +187,7 @@ importers:
         version: 2.2.1
       '@sxzz/test-utils':
         specifier: catalog:dev
-        version: 0.5.6(esbuild@0.25.4)(rolldown@1.0.0-beta.8-commit.05b3e10)(rollup@4.40.2)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.19.4)(yaml@2.7.1))
+        version: 0.5.6(esbuild@0.25.4)(rolldown@1.0.0-beta.8-commit.2a5c6a6)(rollup@4.40.2)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.19.4)(yaml@2.7.1))
       '@types/debug':
         specifier: catalog:dev
         version: 4.1.12
@@ -1008,68 +1008,68 @@ packages:
     resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
     engines: {node: '>=20.0.0'}
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-H0KC/m5kRNoFVF7ObdWH8YNcLCqXIRBEXDbGzjxbLkq/LcoLrdmQeCbLVNKugctGQYiLayyCz9hKkCLqmDqL6A==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-/spXLHL3pRnRueeNbfpnUSzN8jB4B+leIsDsGN0qLiPpKsC4ddknW6ObQ7ZO0zyynGJZy+spXW+Ri9Xaen6+RQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-fiB3ys0xgaHoYiAkwr+awRbY6Mj1ObFptYQNffATafwgCO7AINucaJLqj54ynhDrngcw0xtZkl0dhpQZDOlooA==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-p5AwLDnE5lkCQC7V5EqbskCkT+xba8XaZroINk/UsJ6hlD1ZimnZwlJPDEeGDAzawuEdAbWmvPIaW2RpjXNzXg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-KhdOR1g9aS3QS6vk/aSS7csagIj3GNwyCaaZm9p03VejT49GIBCWWN7O1w3oQdhVMNXiznFmpwa44gEaoEzZSg==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-SfX9uf1UOpDviKA6m3/gcZ8Rn4mKlIiEK28BCL/nFqmfPQ/kK06ISuy07/FpNoNNgYtjpauAGo6ElXw13NIcpw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-E3gLer8C8XpMV4gegn01iMH/H+l9euwXoS4eXhrgzg2TNJGr1/PZSavOgyv24Em+2XO/LNpYA99+Z+nin4+M2A==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-pc5M8Dl0+btKIFwTw19nKBzqgPVbbYVwVBN/hkdwSE2w6D7WjYQJ+2wT31bgIzSIOLar3nLu8vS4o5j4HqSOiA==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-1mIoDHuEynIhQIqip2pnjlaNogHW1k5xUSKH8IFSkxy08trQVKaP+VEoNfKT1ofv4IUOIuVg3/4MmTNYkjUEEQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-t8KwgD5hjyXYZVavfL9DEhqC/nCoyOCJzRZ16iIfadxKn3aSjG9yE0A4/Msz9mGvEmnZ/SOs67hUtbDOo8qGVA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-xQfthFEHvppWTot9/4BTpCm4wOd+PhpLuG2VUDfwZLxrSAUE29C0HRMsa/MGqpoVjYzfOOjoK52/cNjlyPnJgg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-lp0HtDGoR+AIuJH+5M2HmdRhE1x0q8NkdxCs2HlzrUCbFvzwQSAnL/NKevme7VZOP321q0yJ5z9uFL5zfsSbJA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-4PRxKRLTB9a87vNrzGEBkCLcz9rik7kr13zsWX0NmaypMKQ6zahci/C2zdSULgF5CjJhwC3Peime6LULP47cbA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-6O7BdO7bUFQ170MZmNWIpFZpxRqIV1Cp3MfK61tp1VVOwxKo2aboTusuunGMvc59r+JOXqOQFie/ojkecUSvoA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-zDN9oT2qrExmNrXOMiyj6tsPEstQkrVl47Bo2rbWv2kElJotpdvPisy5/CWf9Ds6bURkQGkup2AAS+YQVKGBgA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-KKsXIEUcgV8uv0GNr2KA4oMtG1F8mHUKhyNZriDzfc6D1vXU2uxqV+h+qKwD+7b86Ly041Ks8X+VFjxrdC1q9w==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-/fQX/VcOMzs28n8CfCl29eDFPNw4BZ5tq/4jKef/dtzACPjVOO2IvpnsCgNd0b99RhCAj7plB1ru2cVQR4bpuw==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-eytL/KFiAU10dr56E9jTuwVYg5+UxakZZEIp+TJyE9/LIYtiy6QYw1LxO2zbbX+8YVFwKw4gOk0Cf1ejJ+BQBQ==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-hik89caEQ/FDTxLfOARczkJ0Xk6Rdh7kyMM0TO6IpOXIbTmPPanywT5Sz4SPpNOsuM9Ybid6B9dWSH4+kyaQaQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-0qSs4OmSQ+GANzXD7HuYL2+Ce7qtotmy4Pqhlo5wIEat50vRUK2/pKbRe/5/EAnF9Acr4qxnMrKATUilN+wAEQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-O/XqGff9EdqI1QATkZ/bPgsKAJqWWH71Wv8LS8etlx29021RgJ1RxbAFvdsw35NTzL+A0/Uy7nCZtxvpz1rPaw==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-YYk5Pyjl3Ek3e6NAKIRMF/uFqh+1GjOo/WM9awFxrBstv4p1ZVFqQ1TqbpZrOnjKkLg7YArARF67N1o67JwI1g==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-8bWChtT1JZPT0qqINv0WHQ+tvwYgZ8ltfWXht5vFlKWOmSUDFVcM0pEtmEaY1ALoxeE6M9Nwn9E8w80/dW362Q==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-livj2HgGfV7/54LmwnYQAujR2Ry6DX8q7QxS+d+RtzXyhjvs3QcCgwitIPya88JKdwfN/uP0047O8hIIMgzQlA==}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.8-commit.05b3e10':
-    resolution: {integrity: sha512-mvF7FytqnWD36DyMl9DuKcAT5Z9gyfm8l8rl3CiSYFPTnrTqXwSz1E8C7bPEJBgjUIv6EykNLBNCiq575BhQig==}
+  '@rolldown/pluginutils@1.0.0-beta.8-commit.2a5c6a6':
+    resolution: {integrity: sha512-00vGY8ox2diQ6ZOw9lllyV3e7KrtaczhOz2hsHkOoVIBWyMFGcJD6CpFN10nTLkaaSSqerQjmjxeVwTJH2yhYQ==}
 
   '@rollup/rollup-android-arm-eabi@4.40.2':
     resolution: {integrity: sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==}
@@ -3278,8 +3278,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-beta.8-commit.05b3e10:
-    resolution: {integrity: sha512-thCkUgsSGlVt9sfEwT5Bo2/4oqj8/Ids5qLuIYmi9dhtkybErfe/r9U6iGFG3UwRgrdZqBrN9PajlkPcAzM2EA==}
+  rolldown@1.0.0-beta.8-commit.2a5c6a6:
+    resolution: {integrity: sha512-zRMtW6eT+Q4bQO4wRKu6TtIuyFMrXh/1rFxsR3FS0eJhKjFsaz50gfKlC41QWbGSq5epvE7bdL0j+kZygCrXQA==}
     hasBin: true
     peerDependencies:
       '@oxc-project/runtime': 0.69.0
@@ -4561,45 +4561,45 @@ snapshots:
     dependencies:
       quansync: 0.2.10
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.2a5c6a6':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.9
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.05b3e10':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.8-commit.2a5c6a6':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.8-commit.05b3e10': {}
+  '@rolldown/pluginutils@1.0.0-beta.8-commit.2a5c6a6': {}
 
   '@rollup/rollup-android-arm-eabi@4.40.2':
     optional: true
@@ -4762,14 +4762,14 @@ snapshots:
 
   '@sxzz/prettier-config@2.2.1': {}
 
-  '@sxzz/test-utils@0.5.6(esbuild@0.25.4)(rolldown@1.0.0-beta.8-commit.05b3e10)(rollup@4.40.2)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.19.4)(yaml@2.7.1))':
+  '@sxzz/test-utils@0.5.6(esbuild@0.25.4)(rolldown@1.0.0-beta.8-commit.2a5c6a6)(rollup@4.40.2)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
       tinyglobby: 0.2.13
       unplugin-utils: 0.2.4
       vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.19.4)(yaml@2.7.1)
     optionalDependencies:
       esbuild: 0.25.4
-      rolldown: 1.0.0-beta.8-commit.05b3e10
+      rolldown: 1.0.0-beta.8-commit.2a5c6a6
       rollup: 4.40.2
 
   '@tybys/wasm-util@0.9.0':
@@ -7132,7 +7132,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.11.4(rolldown@1.0.0-beta.8-commit.05b3e10)(typescript@5.8.3):
+  rolldown-plugin-dts@0.11.4(rolldown@1.0.0-beta.8-commit.2a5c6a6)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.27.1
       '@babel/parser': 7.27.2
@@ -7141,30 +7141,30 @@ snapshots:
       debug: 4.4.0
       dts-resolver: 1.2.0
       get-tsconfig: 4.10.0
-      rolldown: 1.0.0-beta.8-commit.05b3e10
+      rolldown: 1.0.0-beta.8-commit.2a5c6a6
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  rolldown@1.0.0-beta.8-commit.05b3e10:
+  rolldown@1.0.0-beta.8-commit.2a5c6a6:
     dependencies:
       '@oxc-project/types': 0.69.0
-      '@rolldown/pluginutils': 1.0.0-beta.8-commit.05b3e10
+      '@rolldown/pluginutils': 1.0.0-beta.8-commit.2a5c6a6
       ansis: 4.0.0
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.8-commit.05b3e10
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.8-commit.05b3e10
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.8-commit.2a5c6a6
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.8-commit.2a5c6a6
 
   rollup@4.40.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ catalogs:
     diff: ^7.0.0
     empathic: ^1.1.0
     hookable: ^5.5.3
-    rolldown: 1.0.0-beta.8-commit.05b3e10
+    rolldown: 1.0.0-beta.8-commit.2a5c6a6
     rolldown-plugin-dts: ^0.11.4
     semver: ^7.7.1
     tinyexec: ^1.0.1


### PR DESCRIPTION
### Description

upgrade rolldown dependency version to latest canary to include https://github.com/rolldown/rolldown/commit/8ac92a4ecfb9fbc328033f936d6aac98c22af0ff which allows for working on https://github.com/rolldown/tsdown/issues/162
It is now possible to use custom loaders, but that ticket should remain open until migration docs / helper are updated as well