### PR TITLE
fix(pnp): resolve typescript peer dependency with Yarn PnP

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "peerDependencies": {
     "publint": "^0.3.0",
     "unplugin-lightningcss": "^0.4.0",
-    "unplugin-unused": "^0.5.0"
+    "unplugin-unused": "^0.5.0",
+    "typescript": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "publint": {
@@ -70,6 +71,9 @@
       "optional": true
     },
     "unplugin-unused": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -59,21 +59,21 @@
   },
   "peerDependencies": {
     "publint": "^0.3.0",
+    "typescript": "^5.0.0",
     "unplugin-lightningcss": "^0.4.0",
-    "unplugin-unused": "^0.5.0",
-    "typescript": "^5.0.0"
+    "unplugin-unused": "^0.5.0"
   },
   "peerDependenciesMeta": {
     "publint": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     },
     "unplugin-lightningcss": {
       "optional": true
     },
     "unplugin-unused": {
-      "optional": true
-    },
-    "typescript": {
       "optional": true
     }
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,7 +5,12 @@ export default defineConfig({
   platform: 'node',
   skipNodeModulesBundle: true,
   shims: true,
-  unused: { level: 'error' },
+  unused: {
+    level: 'error',
+    ignore: [
+      'typescript', // Yarn PnP
+    ],
+  },
   publint: true,
   onSuccess() {
     console.info('🙏 Build succeeded!')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When you run the following command in a Yarn PnP environment:
```sh
yarn tsdown index.ts --dts
```

we get the following error:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/62193eff-2f04-4152-a03f-43233068485e" />

In a Yarn PnP environment, using the `--dts` flag during build causes a peer dependency error. This is required by `rolldown-plugin-dts`.

Although `typescript` is specified as a peer dependency in `rolldown-plugin-dts`, it's bundled within `tsdown`, so if you use only `tsdown`, the peer dependency is not propagated. Therefore, `tsdown` also needs to declare `typescript` as a peer dependency.



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
