### PR TITLE
fix: skip when workspace config has no entry files

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -389,7 +389,9 @@ export async function resolveOptions(options: Options): Promise<{
           files.push(...workspaceFiles)
         }
         return Promise.all(
-          workspaceConfigs.map((config) => resolveConfig(config)),
+          workspaceConfigs
+            .filter((config) => !config.workspace || config.entry?.length)
+            .map((config) => resolveConfig(config)),
         )
       }),
     )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When we simply set `workspace: true` , it should allow the root directory of the workspace to not be the package to be bundled.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
