### PR TITLE
feat: onSuccess Abort Controller

### DIFF
--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -228,7 +228,7 @@ export interface Options {
   /**
    * You can specify command to be executed after a successful build, specially useful for Watch mode
    */
-  onSuccess?: string | ((config: ResolvedOptions) => void | Promise<void>)
+  onSuccess?: string | ((config: ResolvedOptions, signal: AbortSignal) => void | Promise<void>)
 
   /**
    * Skip bundling `node_modules`.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR solves the problem of handling processes that need to be aborted, like custom Bun.spawn or process spawning logic in `onSuccess`. It solves this by switching out the `p.kill` of `tinyexec` for an Abort Controller. 

Additionally the signal from the `AbortController` is provided as the second argument in the `onSuccess` function definition so that it may be used in the callback.

### Linked Issues

N/A

### Additional context

N/A

<!-- e.g. is there anything you'd like reviewers to focus on? -->
