### PR TITLE
fix: regexp needs to reset lastIndex each time test is called

### DIFF
--- a/src/features/external.ts
+++ b/src/features/external.ts
@@ -22,7 +22,11 @@ export function ExternalPlugin(options: ResolvedOptions): Plugin {
         const noExternalPatterns = toArray(noExternal)
         if (
           noExternalPatterns.some((pattern) => {
-            return pattern instanceof RegExp ? pattern.test(id) : id === pattern
+            if (pattern instanceof RegExp) {
+              pattern.lastIndex = 0
+              return pattern.test(id)
+            }
+            return id === pattern
           })
         )
           return


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
If the regular expression passed in carries the `g` modifier, multiple tests may produce unexpected results.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
