### PR TITLE
feat: add banner, footer options

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^2.2.3
       version: 2.2.3
     '@sxzz/test-utils':
-      specifier: ^0.5.6
-      version: 0.5.6
+      specifier: ^0.5.7
+      version: 0.5.7
     '@types/debug':
       specifier: ^4.1.12
       version: 4.1.12
@@ -188,7 +188,7 @@ importers:
         version: 2.2.3
       '@sxzz/test-utils':
         specifier: catalog:dev
-        version: 0.5.6(esbuild@0.25.6)(rolldown@1.0.0-beta.27)(rollup@4.41.1)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(esbuild@0.25.6)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
+        version: 0.5.7(esbuild@0.25.6)(rolldown@1.0.0-beta.27)(rollup@4.41.1)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(esbuild@0.25.6)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))
       '@types/debug':
         specifier: catalog:dev
         version: 4.1.12
@@ -1142,8 +1142,8 @@ packages:
   '@sxzz/prettier-config@2.2.3':
     resolution: {integrity: sha512-J7pmxgW21XYjCRWD+yFjrgnBJPQOXFwSIMQtgZgixfmNS2K9cI7LBEpQwkU43AvYj0eJrm3JvZ6goXLSMGqq1A==}
 
-  '@sxzz/test-utils@0.5.6':
-    resolution: {integrity: sha512-BikHJPOsAqwKIwG5Eg9s8STJMIlg0USi1AdKqTkj9oXt2b/fAK+fV2EVgL1CKD3WQq1622G21AZXWqVLHKC+Lg==}
+  '@sxzz/test-utils@0.5.7':
+    resolution: {integrity: sha512-3NqMKSegD2QmBShLKCIlXdQa1SN7K3QWw6zUMUSbkGp+iKmo/pv6XekOvqeiPeu9qyqVJTKdp9DL4wBX4YfpJg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       esbuild: '>=0.20.0'
@@ -4212,7 +4212,7 @@ snapshots:
     dependencies:
       '@prettier/plugin-oxc': 0.0.4
 
-  '@sxzz/test-utils@0.5.6(esbuild@0.25.6)(rolldown@1.0.0-beta.27)(rollup@4.41.1)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(esbuild@0.25.6)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
+  '@sxzz/test-utils@0.5.7(esbuild@0.25.6)(rolldown@1.0.0-beta.27)(rollup@4.41.1)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(esbuild@0.25.6)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       tinyglobby: 0.2.14
       unplugin-utils: 0.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ catalogs:
     '@arethetypeswrong/core': ^0.18.2
     '@sxzz/eslint-config': ^7.0.6
     '@sxzz/prettier-config': ^2.2.3
-    '@sxzz/test-utils': ^0.5.6
+    '@sxzz/test-utils': ^0.5.7
     '@types/debug': ^4.1.12
     '@types/node': ^24.0.14
     '@types/semver': ^7.7.0

--- a/src/features/output.ts
+++ b/src/features/output.ts
@@ -84,22 +84,22 @@ function createChunkFilename(
 }
 
 export function resolveChunkAddon(
-  bannerOrFooter: ChunkAddon | undefined,
+  chunkAddon: ChunkAddon | undefined,
   format: NormalizedFormat,
 ): AddonFunction | undefined {
-  if (!bannerOrFooter) return
+  if (!chunkAddon) return
 
   return (chunk: RenderedChunk) => {
     const extension = path.extname(chunk.fileName)
 
-    if (typeof bannerOrFooter === 'function') {
-      bannerOrFooter = bannerOrFooter({ format })
+    if (typeof chunkAddon === 'function') {
+      chunkAddon = chunkAddon({ format })
     }
 
     if (extension === '.js') {
-      return bannerOrFooter?.js || ''
+      return chunkAddon?.js || ''
     } else if (extension === '.css') {
-      return bannerOrFooter?.css || ''
+      return chunkAddon?.css || ''
     }
 
     return ''

--- a/src/features/output.ts
+++ b/src/features/output.ts
@@ -2,7 +2,6 @@ import path from 'node:path'
 import { getPackageType, type PackageType } from '../utils/package'
 import type {
   BannerOrFooter,
-  BannerOrFooterOptions,
   NormalizedFormat,
   ResolvedOptions,
 } from '../options'

--- a/src/features/output.ts
+++ b/src/features/output.ts
@@ -1,10 +1,6 @@
 import path from 'node:path'
 import { getPackageType, type PackageType } from '../utils/package'
-import type {
-  BannerOrFooter,
-  NormalizedFormat,
-  ResolvedOptions,
-} from '../options'
+import type { ChunkAddon, NormalizedFormat, ResolvedOptions } from '../options'
 import type {
   AddonFunction,
   InputOptions,
@@ -87,34 +83,25 @@ function createChunkFilename(
   }
 }
 
-export function resolveBannerOrFooter(
-  bannerOrFooter: BannerOrFooter,
+export function resolveChunkAddon(
+  bannerOrFooter: ChunkAddon | undefined,
   format: NormalizedFormat,
 ): AddonFunction | undefined {
-  return bannerOrFooter
-    ? (chunk: RenderedChunk) => {
-        const fileName = chunk.fileName
-        const extension = path.extname(fileName)
+  if (!bannerOrFooter) return
 
-        if (typeof bannerOrFooter === 'function') {
-          const option = bannerOrFooter({ format })
+  return (chunk: RenderedChunk) => {
+    const extension = path.extname(chunk.fileName)
 
-          if (option && 'js' in option && extension === '.js') {
-            return option.js
-          }
-          if (option && 'css' in option && extension === '.css') {
-            return option.css
-          }
-        } else {
-          if ('js' in bannerOrFooter && extension === '.js') {
-            return bannerOrFooter.js
-          }
-          if ('css' in bannerOrFooter && extension === '.css') {
-            return bannerOrFooter.css
-          }
-        }
+    if (typeof bannerOrFooter === 'function') {
+      bannerOrFooter = bannerOrFooter({ format })
+    }
 
-        return '' // fallback
-      }
-    : undefined
+    if (extension === '.js') {
+      return bannerOrFooter?.js || ''
+    } else if (extension === '.css') {
+      return bannerOrFooter?.css || ''
+    }
+
+    return ''
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { ExternalPlugin } from './features/external'
 import { createHooks } from './features/hooks'
 import { LightningCSSPlugin } from './features/lightningcss'
 import { NodeProtocolPlugin } from './features/node-protocol'
-import { resolveBannerOrFooter, resolveChunkFilename } from './features/output'
+import { resolveChunkAddon, resolveChunkFilename } from './features/output'
 import { publint } from './features/publint'
 import { ReportPlugin } from './features/report'
 import { getShimsInject } from './features/shims'
@@ -314,8 +314,8 @@ async function getBuildOptions(
       preserveModulesRoot: unbundle
         ? lowestCommonAncestor(...Object.values(entry))
         : undefined,
-      banner: resolveBannerOrFooter(banner, format),
-      footer: resolveBannerOrFooter(footer, format),
+      banner: resolveChunkAddon(banner, format),
+      footer: resolveChunkAddon(footer, format),
     },
     config.outputOptions,
     [format],

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { ExternalPlugin } from './features/external'
 import { createHooks } from './features/hooks'
 import { LightningCSSPlugin } from './features/lightningcss'
 import { NodeProtocolPlugin } from './features/node-protocol'
-import { resolveChunkFilename } from './features/output'
+import { resolveBannerOrFooter, resolveChunkFilename } from './features/output'
 import { publint } from './features/publint'
 import { ReportPlugin } from './features/report'
 import { getShimsInject } from './features/shims'
@@ -215,6 +215,8 @@ async function getBuildOptions(
     loader,
     name,
     unbundle,
+    banner,
+    footer,
   } = config
 
   const plugins: RolldownPluginOption = []
@@ -312,6 +314,8 @@ async function getBuildOptions(
       preserveModulesRoot: unbundle
         ? lowestCommonAncestor(...Object.values(entry))
         : undefined,
+      banner: resolveBannerOrFooter(banner, format),
+      footer: resolveBannerOrFooter(footer, format),
     },
     config.outputOptions,
     [format],

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -203,6 +203,8 @@ async function resolveConfig(
     unbundle = typeof bundle === 'boolean' ? !bundle : false,
     removeNodeProtocol,
     nodeProtocol,
+    banner = () => undefined,
+    footer = () => undefined,
   } = userConfig
 
   if (typeof bundle === 'boolean') {
@@ -313,6 +315,8 @@ async function resolveConfig(
     exports,
     unbundle,
     nodeProtocol,
+    banner,
+    footer,
   }
 
   return config

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -203,8 +203,6 @@ async function resolveConfig(
     unbundle = typeof bundle === 'boolean' ? !bundle : false,
     removeNodeProtocol,
     nodeProtocol,
-    banner = () => undefined,
-    footer = () => undefined,
   } = userConfig
 
   if (typeof bundle === 'boolean') {
@@ -315,8 +313,6 @@ async function resolveConfig(
     exports,
     unbundle,
     nodeProtocol,
-    banner,
-    footer,
   }
 
   return config

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -2,7 +2,7 @@ import type { AttwOptions } from '../features/attw'
 import type { CopyOptions, CopyOptionsFn } from '../features/copy'
 import type { ExportsOptions } from '../features/exports'
 import type { TsdownHooks } from '../features/hooks'
-import type { OutExtensionFactory } from '../features/output'
+import type { ChunkAddon, OutExtensionFactory } from '../features/output'
 import type { ReportOptions } from '../features/report'
 import type {
   Arrayable,
@@ -62,15 +62,6 @@ export interface Workspace {
    */
   config?: boolean | string
 }
-
-export interface ChunkAddonObject {
-  js?: string
-  css?: string
-}
-export type ChunkAddonFunction = (ctx: {
-  format: Format
-}) => ChunkAddonObject | undefined
-export type ChunkAddon = ChunkAddonObject | ChunkAddonFunction
 
 /**
  * Options for tsdown.

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -63,6 +63,15 @@ export interface Workspace {
   config?: boolean | string
 }
 
+export type BannerOrFooterOptions =
+  | { js: string }
+  | { css: string }
+  | { js: string; css: string }
+
+export type BannerOrFooter =
+  | BannerOrFooterOptions
+  | ((ctx: { format: Format }) => BannerOrFooterOptions | undefined)
+
 /**
  * Options for tsdown.
  */
@@ -118,7 +127,7 @@ export interface Options {
   /** @default false */
   minify?: boolean | 'dce-only' | MinifyOptions
   /**
-   * Specifies the compilation target environment(s).
+   * Specifies the compilation target environAnt(s).
    *
    * Determines the JavaScript version or runtime(s) for which the code should be compiled.
    * If not set, defaults to the value of `engines.node` in your project's `package.json`.
@@ -359,6 +368,8 @@ export interface Options {
    * Filter workspace packages. This option is only available in workspace mode.
    */
   filter?: RegExp | string | string[]
+  footer?: BannerOrFooter
+  banner?: BannerOrFooter
 }
 
 /**

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -63,14 +63,14 @@ export interface Workspace {
   config?: boolean | string
 }
 
-export type BannerOrFooterOptions =
-  | { js: string }
-  | { css: string }
-  | { js: string; css: string }
-
-export type BannerOrFooter =
-  | BannerOrFooterOptions
-  | ((ctx: { format: Format }) => BannerOrFooterOptions | undefined)
+export interface ChunkAddonObject {
+  js?: string
+  css?: string
+}
+export type ChunkAddonFunction = (ctx: {
+  format: Format
+}) => ChunkAddonObject | undefined
+export type ChunkAddon = ChunkAddonObject | ChunkAddonFunction
 
 /**
  * Options for tsdown.
@@ -368,8 +368,8 @@ export interface Options {
    * Filter workspace packages. This option is only available in workspace mode.
    */
   filter?: RegExp | string | string[]
-  footer?: BannerOrFooter
-  banner?: BannerOrFooter
+  footer?: ChunkAddon
+  banner?: ChunkAddon
 }
 
 /**
@@ -400,6 +400,8 @@ export type ResolvedOptions = Omit<
       | 'loader'
       | 'name'
       | 'bundle'
+      | 'banner'
+      | 'footer'
     >,
     {
       format: NormalizedFormat[]

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -127,7 +127,7 @@ export interface Options {
   /** @default false */
   minify?: boolean | 'dce-only' | MinifyOptions
   /**
-   * Specifies the compilation target environAnt(s).
+   * Specifies the compilation target environment(s).
    *
    * Determines the JavaScript version or runtime(s) for which the code should be compiled.
    * If not set, defaults to the value of `engines.node` in your project's `package.json`.

--- a/tests/__snapshots__/banner-and-footer-option.snap.md
+++ b/tests/__snapshots__/banner-and-footer-option.snap.md
@@ -1,0 +1,10 @@
+## index.js
+
+```js
+// banner
+//#region index.ts
+console.log("Hello, world!");
+
+//#endregion
+// footer
+```

--- a/tests/__snapshots__/banner-and-footer-option.snap.md
+++ b/tests/__snapshots__/banner-and-footer-option.snap.md
@@ -1,10 +1,15 @@
+## index.d.ts
+
+```ts
+export { };
+```
 ## index.js
 
 ```js
-// banner
+// js banner
 //#region index.ts
 console.log("Hello, world!");
 
 //#endregion
-// footer
+// js footer
 ```

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -411,21 +411,27 @@ test('workspace option', async (context) => {
 
 test('banner and footer option', async (context) => {
   const content = `console.log("Hello, world!")`
-  const { snapshot } = await testBuild({
+  const { fileMap } = await testBuild({
     context,
     files: {
       'index.ts': content,
     },
     options: {
+      dts: true,
       banner: {
-        js: '// banner',
+        js: '// js banner',
+        dts: '// dts banner',
       },
       footer: {
-        js: '// footer',
+        js: '// js footer',
+        dts: '// dts footer',
       },
     },
   })
-  expect(snapshot).toContain('// banner')
-  expect(snapshot).toContain('// footer')
-  expect(snapshot).toContain(content)
+
+  expect(fileMap['index.js']).toContain('// js banner')
+  expect(fileMap['index.js']).toContain('// js footer')
+
+  // expect(fileMap['index.d.ts']).toContain('// dts banner')
+  // expect(fileMap['index.d.ts']).toContain('// dts footer')
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -408,3 +408,24 @@ test('workspace option', async (context) => {
     expectPattern: '**/dist',
   })
 })
+
+test('banner and footer option', async (context) => {
+  const content = `console.log("Hello, world!")`
+  const { snapshot } = await testBuild({
+    context,
+    files: {
+      'index.ts': content,
+    },
+    options: {
+      banner: {
+        js: '// banner',
+      },
+      footer: {
+        js: '// footer',
+      },
+    },
+  })
+  expect(snapshot).toContain('// banner')
+  expect(snapshot).toContain('// footer')
+  expect(snapshot).toContain(content)
+})

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -122,6 +122,7 @@ export async function testBuild({
   outputFiles: string[]
   outputDir: string
   snapshot: string
+  fileMap: Record<string, string>
 }> {
   const { expect } = context
   const { testName, testDir } = await writeFixtures(context, files, fixture)
@@ -141,7 +142,11 @@ export async function testBuild({
   restoreCwd()
 
   const outputDir = path.resolve(workingDir, resolvedOptions.outDir!)
-  const { files: outputFiles, snapshot } = await expectFilesSnapshot(
+  const {
+    files: outputFiles,
+    snapshot,
+    fileMap,
+  } = await expectFilesSnapshot(
     path.resolve(outputDir, expectDir),
     path.resolve(snapshotsDir, `${testName}.snap.md`),
     { pattern: expectPattern, expect },
@@ -153,6 +158,7 @@ export async function testBuild({
     outputFiles,
     outputDir,
     snapshot,
+    fileMap,
   }
 }
 


### PR DESCRIPTION
### Description

Hello. I'm an enthusiast of tsup and have great interest in the tsdown project.
This PR is merely a suggestion and I submitted it with the intention of having a discussion with you.
If this PR doesn't align with the direction of tsdown, please feel free to close it.

tsdown is a project inspired by tsup, and in fact, many of its configuration structures and core philosophies are designed similarly.
For that reason, tsup users who switch to tsdown inevitably expect a similar developer experience (DX).
I believe the banner and footer features fall within that context. These are widely used in various bundlers such as Rollup, esbuild, and webpack, and have been supported in tsup as well.

However, since tsdown currently uses rolldown internally, although the functionality itself is easy to implement, the configuration method has changed.
As a result, existing tsup users face an unnecessary entry barrier by having to look up documentation again or modify their existing configurations.
I believe this isn't just an interface difference, but a factor that causes friction during migration.

To become a project that tsup users can naturally transition to, I think it's important to maintain as much functional parity and consistency in configuration interface as possible. (Just my opinion.)
This PR, as part of that, proposes adopting the same banner/footer configuration style as tsup.

Of course, due to rolldown's structure, the future direction may change.
If so, I think we could proceed by separating it through a breaking change via versioning later on.
However, at this stage, encouraging user adoption with low friction and then shaping the direction seems like a more strategic approach.
The fact that users can transition with a similar API and minimal configuration changes could offer great convenience.

### Linked Issues

closed: #288 
