### PR TITLE
feat: add `watch.usePolling` , `watch.atomic` and `watch.path`

### DIFF
--- a/src/features/watch.ts
+++ b/src/features/watch.ts
@@ -21,7 +21,13 @@ export async function watchBuild(
   }
 
   const files = toArray(
-    typeof options.watch === 'boolean' ? options.cwd : options.watch,
+    typeof options.watch === 'boolean'
+      ? options.cwd
+      : typeof options.watch === 'object' && 'path' in options.watch
+        ? options.watch.path
+        : typeof options.watch === 'object'
+          ? options.cwd
+          : options.watch,
   )
   logger.info(`Watching for changes in ${files.join(', ')}`)
   files.push(...configFiles)
@@ -29,7 +35,19 @@ export async function watchBuild(
   const { watch } = await import('chokidar')
   const debouncedRebuild = debounce(rebuild, 100)
 
+  const usePolling =
+    typeof options.watch === 'object' &&
+    'usePolling' in options.watch &&
+    options.watch?.usePolling
+
+  const atomic =
+    typeof options.watch === 'object' &&
+    'atomic' in options.watch &&
+    options.watch?.atomic
+
   const watcher = watch(files, {
+    usePolling,
+    atomic,
     ignoreInitial: true,
     ignorePermissionErrors: true,
     ignored: [

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -205,7 +205,35 @@ export interface Options {
    */
   config?: boolean | string
   /** @default false */
-  watch?: boolean | string | string[]
+  watch?:
+    | boolean
+    | string
+    | string[]
+    | {
+        /**
+         * The directory or files to watch for changes.
+         * If set to `true`, it will watch the current working directory.
+         * If set to `false`, it will not watch any files.
+         */
+        path: string | string[]
+
+        /**
+         * Whether to use fs.watchFile (backed by polling), or fs.watch. If polling leads to high CPU
+         * utilization, consider setting this to `false`. It is typically necessary to **set this to
+         * `true` to successfully watch files over a network**, and it may be necessary to successfully
+         * watch files in other non-standard situations.
+         */
+        usePolling?: boolean
+
+        /**
+         * `true` if `usePolling` is `false`. Automatically filters out artifacts
+         * that occur when using editors that use "atomic writes" instead of writing directly to the
+         * source file. If a file is re-added within 100 ms of being deleted, Chokidar emits a `change`
+         * event rather than `unlink` then `add`. If the default of 100 ms does not work well for you,
+         * you can override it by setting `atomic` to a custom value, in milliseconds.
+         */
+        atomic?: boolean | number
+      }
   ignoreWatch?: string | string[]
 
   /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adds support for chokidar `usePolling` and `atomic` options similar to vite's

### Linked Issues

closes #355

### Additional context

I see https://github.com/rolldown/tsdown/pull/329 which removes chokidar in favor of rolldown's watcher, which afaik doesn't have polling option (correct me if I am wrong), so if this PR needs to be closed and the feature should be implemented in rolldown instead, I don't mind, I can contribute to rolldown.  

<!-- e.g. is there anything you'd like reviewers to focus on? -->
