### PR TITLE
fix(workspace): path compatibility issue under windows

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import { blue } from 'ansis'
 import Debug from 'debug'
 import { glob } from 'tinyglobby'
+import { normalizePath } from 'vite'
 import { resolveClean } from '../features/clean'
 import { resolveEntry } from '../features/entry'
 import { resolveTarget } from '../features/target'
@@ -99,7 +100,7 @@ async function resolveWorkspace(
       })
     )
       .filter((file) => file !== 'package.json') // exclude root package.json
-      .map((file) => path.resolve(rootCwd, file, '..'))
+      .map((file) => normalizePath(path.resolve(rootCwd, file, '..')))
   } else {
     packages = (
       await glob({
@@ -109,7 +110,7 @@ async function resolveWorkspace(
         onlyDirectories: true,
         absolute: true,
       })
-    ).map((file) => path.resolve(file))
+    ).map((file) => normalizePath(path.resolve(file)))
   }
 
   if (packages.length === 0) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In Windows, the package index package will have a path error, I use [normalizepath ](https://vite.dev/guide/api-javascript.html#normalizepath) to normalize the path to solve this compatibility error.

<img width="1131" height="957" alt="559f8f3801df5308601a4a4eeb3a0aea" src="https://github.com/user-attachments/assets/db2a411b-b80b-4519-a46c-b85511d9cbf1" />

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
