### PR TITLE
fix(types): keep type of options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,9 +3,9 @@ import type { UserConfig, UserConfigFn } from './options'
 /**
  * Defines the configuration for tsdown.
  */
-export function defineConfig(
-  options: UserConfig | UserConfigFn,
-): UserConfig | UserConfigFn {
+export function defineConfig<const T extends UserConfig | UserConfigFn>(
+  options: T,
+): T {
   return options
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When using `defineConfig({})`, the return value cannot be spread because the type includes a function. Since the `defineConfig()` is just the identity function, it might be better to keep the type as is. Another option is to create an overload function

### Linked Issues

### Additional context

The current workaround is to use `satisfies UserOptions`

<!-- e.g. is there anything you'd like reviewers to focus on? -->
