### PR TITLE
fix(docs): add responsive styles for sponsor SVG on mobile

### DIFF
--- a/docs/.vitepress/components/HomePage.vue
+++ b/docs/.vitepress/components/HomePage.vue
@@ -57,4 +57,9 @@ onMounted(async () => {
 .dark .voidzero {
   background-image: url(https://voidzero.dev/logo-white.svg);
 }
+
+:deep(svg) {
+  max-width: 100%;
+  height: auto;
+}
 </style>


### PR DESCRIPTION
  fix(docs): add responsive styles for sponsor SVG on mobile

  ## Description
  Add `:deep(svg)` styles to prevent sponsor section overflow on mobile devices. The SVG is injected
   via `v-html` and requires deep selector to apply styles.

  ## Linked Issues
  -

  ## Additional context
  Minimal CSS-only fix without additional markup changes.