### PR TITLE
docs: clarify behavior of `name` option

### DIFF
--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -161,7 +161,8 @@ export interface Options {
 
   /**
    * The name to show in CLI output. This is useful for monorepos or workspaces.
-   * Defaults to the package name from `package.json`.
+   * When using workspace mode, this option defaults to the package name from package.json.
+   * In non-workspace mode, this option must be set explicitly for the name to show in the CLI output.
    */
   name?: string
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Clarifies the documentation for the name option.
Now explicitly states that the name will default to the package name from package.json only in workspace mode, and must be set manually in non-workspace mode for it to appear in the CLI output.

### Linked Issues

https://github.com/rolldown/tsdown/issues/386

### Additional context

none
