### PR TITLE
feat: exports with dir index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": true,
-  "cSpell.words": ["tsdown"],
+  "cSpell.words": ["rolldown", "tsdown"],
   "files.readonlyInclude": {
     "docs/**/reference/api/**": true
   },

--- a/src/features/exports.test.ts
+++ b/src/features/exports.test.ts
@@ -72,6 +72,30 @@ describe.concurrent('generateExports', () => {
     `)
   })
 
+  test('index entry in dir', async ({ expect }) => {
+    const results = generateExports(
+      FAKE_PACKAGE_JSON,
+      cwd,
+      {
+        es: [genChunk('index.js'), genChunk('foo/index.js')],
+      },
+      {},
+    )
+    await expect(results).resolves.toMatchInlineSnapshot(`
+      {
+        "exports": {
+          ".": "./index.js",
+          "./foo": "./foo/index.js",
+          "./package.json": "./package.json",
+        },
+        "main": "./index.js",
+        "module": "./index.js",
+        "publishExports": undefined,
+        "types": undefined,
+      }
+    `)
+  })
+
   test('multiple entries', async ({ expect }) => {
     const results = generateExports(
       FAKE_PACKAGE_JSON,

--- a/src/features/exports.ts
+++ b/src/features/exports.ts
@@ -142,7 +142,8 @@ export async function generateExports(
           }
         }
       } else {
-        name = `./${name}`
+        const isDirIndex = name.endsWith('/index')
+        name = isDirIndex ? `./${name.slice(0, -6)}` : `./${name}`
       }
 
       let subExport = exportsMap.get(name)


### PR DESCRIPTION
### Description

Add a feature for `exports`, if an entry is a directory with an `index` file, it will now exported as the directory name instead of the full path to `index`.

For example:

```ts
import { defineConfig } from 'tsdown'

export default defineConfig({
  entry: ['src/index.ts', 'src/foo'],
})
```

with result in the following change in `package.json`:

```diff
{
  "exports": {
    ".": "./dist/index.js",
-    "./foo/index": "./dist/foo/index.js",
+    "./foo": "./dist/foo/index.js",
    "./package.json": "./package.json"
  }
}
```

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
