### PR TITLE
fix: clean outDir on rebuilds in watch mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,11 @@ export async function buildSingle(
     await hooks.callHook('build:prepare', context)
     ab?.abort()
 
-    await clean()
+    if (first) {
+      await clean()
+    } else {
+      await cleanOutDir([config]);
+    }
 
     let hasErrors = false
     const isMultiFormat = formats.length > 1


### PR DESCRIPTION
### Description

The out directory is now cleaned on subsequent rebuilds in watch mode, not just on the first build.

### Linked Issues

fix #397

### Additional context

I'm not sure if this is the right approach, but I kept the existing `clean()` method since it looked pretty intentional, maybe it prevents race conditions in the order in which directories are cleaned if their are multiple configs in tsdown.config.ts? Anyway on rebuilds it will only be triggered for a specific directory.
