### PR TITLE
feat: support silent as programmatic usage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 import process from 'node:process'
+import { dim } from 'ansis'
 import { cac } from 'cac'
 import debug from 'debug'
+import { VERSION as rolldownVersion } from 'rolldown'
 import { version } from '../package.json'
 import { resolveComma, toArray } from './utils/general'
 import { logger } from './utils/logger'
@@ -59,6 +61,9 @@ cli
   )
   .action(async (input: string[], flags: Options) => {
     logger.setSilent(!!flags.silent)
+    logger.info(
+      `tsdown ${dim`v${version}`} powered by rolldown ${dim`v${rolldownVersion}`}`,
+    )
     const { build } = await import('./index')
     if (input.length > 0) flags.entry = input
     await build(flags)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,6 @@
 import process from 'node:process'
-import { dim } from 'ansis'
 import { cac } from 'cac'
 import debug from 'debug'
-import { VERSION as rolldownVersion } from 'rolldown'
 import { version } from '../package.json'
 import { resolveComma, toArray } from './utils/general'
 import { logger } from './utils/logger'
@@ -61,9 +59,6 @@ cli
   )
   .action(async (input: string[], flags: Options) => {
     logger.setSilent(!!flags.silent)
-    logger.info(
-      `tsdown ${dim`v${version}`} powered by rolldown ${dim`v${rolldownVersion}`}`,
-    )
     const { build } = await import('./index')
     if (input.length > 0) flags.entry = input
     await build(flags)

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,6 @@ import type { Options as DtsOptions } from 'rolldown-plugin-dts'
  * Build with tsdown.
  */
 export async function build(userOptions: Options = {}): Promise<void> {
-  if (typeof userOptions.silent === 'boolean') {
-    logger.setSilent(userOptions.silent)
-  }
-
   const { configs, files: configFiles } = await resolveOptions(userOptions)
 
   let cleanPromise: Promise<void> | undefined

--- a/src/options/config.ts
+++ b/src/options/config.ts
@@ -1,8 +1,10 @@
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
-import { underline } from 'ansis'
+import { dim, underline } from 'ansis'
+import { VERSION as rolldownVersion } from 'rolldown'
 import { loadConfig } from 'unconfig'
+import { version } from '../../package.json'
 import { fsStat } from '../utils/fs'
 import { toArray } from '../utils/general'
 import { logger } from '../utils/logger'
@@ -109,17 +111,27 @@ export async function loadConfigFile(
     })
     .finally(() => (loaded = true))
 
-  const file = sources[0]
-  if (file) {
-    logger.info(`Using tsdown config: ${underline(file)}`)
-  }
-
   if (typeof config === 'function') {
     config = await config(options)
   }
   config = toArray(config)
   if (config.length === 0) {
     config.push({})
+  }
+
+  // If one of the configs has the `silent` option to true, set the logger to silent mode.
+  // There shouldn't be any log before this point, as that would ignore the silent option.
+  if (config.some((c) => c.silent)) {
+    logger.setSilent(true)
+  }
+
+  logger.info(
+    `tsdown ${dim`v${version}`} powered by rolldown ${dim`v${rolldownVersion}`}`,
+  )
+
+  const file = sources[0]
+  if (file) {
+    logger.info(`Using tsdown config: ${underline(file)}`)
   }
   return {
     configs: config,

--- a/src/options/config.ts
+++ b/src/options/config.ts
@@ -1,10 +1,8 @@
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
-import { dim, underline } from 'ansis'
-import { VERSION as rolldownVersion } from 'rolldown'
+import { underline } from 'ansis'
 import { loadConfig } from 'unconfig'
-import { version } from '../../package.json'
 import { fsStat } from '../utils/fs'
 import { toArray } from '../utils/general'
 import { logger } from '../utils/logger'
@@ -124,10 +122,6 @@ export async function loadConfigFile(
   if (config.some((c) => c.silent)) {
     logger.setSilent(true)
   }
-
-  logger.info(
-    `tsdown ${dim`v${version}`} powered by rolldown ${dim`v${rolldownVersion}`}`,
-  )
 
   const file = sources[0]
   if (file) {


### PR DESCRIPTION
### Description

Wasn't sure how to correctly implement this one, it pretty much implies to load the config file before logging anything, that makes logging a bit annoying at the beginning of the process.

### Linked Issues

Resolves #359 
