### PR TITLE
docs: add react support page

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -99,7 +99,10 @@ export function getLocaleConfig(lang: string) {
     {
       text: t('Recipes'),
       base: `${urlPrefix}/recipes`,
-      items: [{ text: t('Vue Support'), link: '/vue-support.md' }],
+      items: [
+        { text: t('Vue Support'), link: '/vue-support.md' },
+        { text: t('React Support'), link: '/react-support.md' },
+      ],
     },
     {
       text: t('Advanced'),

--- a/docs/.vitepress/i18n/translate-map.ts
+++ b/docs/.vitepress/i18n/translate-map.ts
@@ -30,6 +30,7 @@ export const zhCN = {
 
   Recipes: '实践指南',
   'Vue Support': 'Vue 支持',
+  'React Support': 'React 支持',
 
   Advanced: '高级功能',
   'Rolldown Options': 'Rolldown 选项',

--- a/docs/recipes/react-support.md
+++ b/docs/recipes/react-support.md
@@ -1,0 +1,68 @@
+# React Support
+
+`tsdown` provides first-class support for building React component libraries. As [Rolldown](https://rolldown.rs/) natively supports bundling JSX/TSX files, you don't need any additional plugins to get started.
+
+## Quick Start
+
+For the fastest way to get started, use the React component starter template. This starter project comes pre-configured for React library development, so you can focus on building components right away.
+
+```bash
+npx create-tsdown@latest -t react
+```
+
+## Minimal Example
+
+To configure `tsdown` for a React library, you can just use a standard `tsdown.config.ts`:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig([
+  {
+    entry: ['./src/index.ts'],
+    platform: 'neutral',
+    dts: true,
+  },
+])
+```
+
+Create your typical React component:
+
+```tsx [MyButton.tsx]
+import React from 'react'
+
+interface MyButtonProps {
+  type?: 'primary'
+}
+
+export const MyButton: React.FC<MyButtonProps> = ({ type }) => {
+  return <button className="my-button">my button: type {type}</button>
+}
+```
+
+And import it in your entry file:
+
+```ts [index.ts]
+export { MyButton } from './MyButton'
+```
+
+::: warning
+
+There are 2 ways of transforming JSX/TSX files in `tsdown`:
+
+- **classic**
+- **automatic** (default)
+
+If you need to use classic JSX transformation, you can configure Rolldown's [`inputOptions.jsx`](https://rolldown.rs/reference/config-options#jsx) option in your configuration file:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  inputOptions: {
+    jsx: 'react', // Use classic JSX transformation
+  },
+})
+```
+
+:::

--- a/docs/recipes/vue-support.md
+++ b/docs/recipes/vue-support.md
@@ -4,7 +4,11 @@
 
 ## Quick Start
 
-For the fastest way to get started, use the [vue-components-starter](https://github.com/sxzz/vue-components-starter) template. This starter project comes pre-configured for Vue library development, so you can focus on building components right away.
+For the fastest way to get started, use the Vue component starter template. This starter project comes pre-configured for React library development, so you can focus on building components right away.
+
+```bash
+npx create-tsdown@latest -t vue
+```
 
 ## Minimal Example
 


### PR DESCRIPTION
### Description

Adds a "React Support" page.

Also modified the "Vue Support" page to use `create-tsdown` instead of pointing to the starter repo.

### Linked Issues

Closes #324 
