### PR TITLE
feat: enable dts if exports.types exists

### DIFF
--- a/src/features/exports.ts
+++ b/src/features/exports.ts
@@ -243,3 +243,33 @@ function exportMeta(exports: Record<string, any>, all?: boolean) {
     exports['./package.json'] = './package.json'
   }
 }
+
+export function hasExportsTypes(pkg?: PackageJson): boolean {
+  const exports = pkg?.exports
+  if (!exports) return false
+
+  if (
+    typeof exports === 'object' &&
+    exports !== null &&
+    !Array.isArray(exports)
+  ) {
+    // Check if exports.types exists
+    if ('types' in exports) {
+      return true
+    }
+
+    // Check if exports['.'].types exists
+    if ('.' in exports) {
+      const mainExport = exports['.']
+      if (
+        typeof mainExport === 'object' &&
+        mainExport !== null &&
+        'types' in mainExport
+      ) {
+        return true
+      }
+    }
+  }
+
+  return false
+}

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -22,15 +22,20 @@ const debug = Debug('tsdown:options')
 function hasExportsTypes(pkg: PackageJson | undefined): boolean {
   if (!pkg?.exports) return false
   
-  // Type-safe handling of exports object
-  const exports = pkg.exports as any
+  const exports = pkg.exports
   
   // Check if exports.types exists
-  if (exports.types) return true
+  if (typeof exports === 'object' && exports !== null && 'types' in exports) {
+    return true
+  }
   
-  // Check if exports['.'].types exists (with type safety)
-  const mainExport = exports['.']
-  if (mainExport && typeof mainExport === 'object' && mainExport.types) return true
+  // Check if exports['.'].types exists
+  if (typeof exports === 'object' && exports !== null && '.' in exports) {
+    const mainExport = (exports as Record<string, unknown>)['.']
+    if (typeof mainExport === 'object' && mainExport !== null && 'types' in mainExport) {
+      return true
+    }
+  }
   
   return false
 }

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -10,6 +10,7 @@ import { resolveTsconfig } from '../features/tsconfig'
 import { resolveRegex, slash, toArray } from '../utils/general'
 import { createLogger } from '../utils/logger'
 import { normalizeFormat, readPackageJson } from '../utils/package'
+import type { PackageJson } from 'pkg-types'
 import type { Awaitable } from '../utils/types'
 import { loadConfigFile, loadViteConfig } from './config'
 import type { NormalizedUserConfig, Options, ResolvedOptions } from './types'
@@ -17,6 +18,18 @@ import type { NormalizedUserConfig, Options, ResolvedOptions } from './types'
 export * from './types'
 
 const debug = Debug('tsdown:options')
+
+function hasExportsTypes(pkg: PackageJson | undefined): boolean {
+  if (!pkg?.exports) return false
+  
+  // Check if exports.types exists
+  if (pkg.exports.types) return true
+  
+  // Check if exports['.'].types exists
+  if (pkg.exports['.'] && pkg.exports['.'].types) return true
+  
+  return false
+}
 
 const DEFAULT_EXCLUDE_WORKSPACE = [
   '**/node_modules/**',
@@ -230,7 +243,7 @@ async function resolveConfig(
   }
   entry = await resolveEntry(logger, entry, cwd, name)
   if (dts == null) {
-    dts = !!(pkg?.types || pkg?.typings)
+    dts = !!(pkg?.types || pkg?.typings || hasExportsTypes(pkg))
   }
   target = resolveTarget(logger, target, pkg, name)
   tsconfig = await resolveTsconfig(logger, tsconfig, cwd, name)

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -5,12 +5,12 @@ import Debug from 'debug'
 import { glob } from 'tinyglobby'
 import { resolveClean } from '../features/clean'
 import { resolveEntry } from '../features/entry'
+import { hasExportsTypes } from '../features/exports'
 import { resolveTarget } from '../features/target'
 import { resolveTsconfig } from '../features/tsconfig'
 import { resolveRegex, slash, toArray } from '../utils/general'
 import { createLogger } from '../utils/logger'
 import { normalizeFormat, readPackageJson } from '../utils/package'
-import type { PackageJson } from 'pkg-types'
 import type { Awaitable } from '../utils/types'
 import { loadConfigFile, loadViteConfig } from './config'
 import type { NormalizedUserConfig, Options, ResolvedOptions } from './types'
@@ -18,27 +18,6 @@ import type { NormalizedUserConfig, Options, ResolvedOptions } from './types'
 export * from './types'
 
 const debug = Debug('tsdown:options')
-
-function hasExportsTypes(pkg: PackageJson | undefined): boolean {
-  if (!pkg?.exports) return false
-  
-  const exports = pkg.exports
-  
-  // Check if exports.types exists
-  if (typeof exports === 'object' && exports !== null && 'types' in exports) {
-    return true
-  }
-  
-  // Check if exports['.'].types exists
-  if (typeof exports === 'object' && exports !== null && '.' in exports) {
-    const mainExport = (exports as Record<string, unknown>)['.']
-    if (typeof mainExport === 'object' && mainExport !== null && 'types' in mainExport) {
-      return true
-    }
-  }
-  
-  return false
-}
 
 const DEFAULT_EXCLUDE_WORKSPACE = [
   '**/node_modules/**',

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -22,11 +22,14 @@ const debug = Debug('tsdown:options')
 function hasExportsTypes(pkg: PackageJson | undefined): boolean {
   if (!pkg?.exports) return false
   
+  // Type-safe handling of exports object
+  const exports = pkg.exports as any
+  
   // Check if exports.types exists
-  if (pkg.exports.types) return true
+  if (exports.types) return true
   
   // Check if exports['.'].types exists (with type safety)
-  const mainExport = pkg.exports['.']
+  const mainExport = exports['.']
   if (mainExport && typeof mainExport === 'object' && mainExport.types) return true
   
   return false

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -25,8 +25,9 @@ function hasExportsTypes(pkg: PackageJson | undefined): boolean {
   // Check if exports.types exists
   if (pkg.exports.types) return true
   
-  // Check if exports['.'].types exists
-  if (pkg.exports['.'] && pkg.exports['.'].types) return true
+  // Check if exports['.'].types exists (with type safety)
+  const mainExport = pkg.exports['.']
+  if (mainExport && typeof mainExport === 'object' && mainExport.types) return true
   
   return false
 }

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -366,11 +366,11 @@ export interface Options {
   //#region Addons
 
   /**
-   * Emit TypeScript declaration files (.d.ts).
+   * Enables generation of TypeScript declaration files (`.d.ts`).
    *
-   * By default, this feature is auto-detected based on the presence of the `types` field in the `package.json` file.
-   * - If the `types` field is present in `package.json`, declaration file emission is enabled.
-   * - If the `types` field is absent, declaration file emission is disabled by default.
+   * By default, this option is auto-detected based on your project's `package.json`:
+   * - If the `types` field is present, or if the main `exports` contains a `types` entry, declaration file generation is enabled by default.
+   * - Otherwise, declaration file generation is disabled by default.
    */
   dts?: boolean | DtsOptions
 

--- a/tests/__snapshots__/dts-enabled-when-exports-types-exists.snap.md
+++ b/tests/__snapshots__/dts-enabled-when-exports-types-exists.snap.md
@@ -1,0 +1,17 @@
+## index.d.mts
+
+```mts
+//#region index.d.ts
+declare const hello = "world";
+//#endregion
+export { hello };
+```
+## index.mjs
+
+```mjs
+//#region index.ts
+const hello = "world";
+
+//#endregion
+export { hello };
+```

--- a/tests/__snapshots__/dts-not-enabled-when-exports-is-string-instead-of-object.snap.md
+++ b/tests/__snapshots__/dts-not-enabled-when-exports-is-string-instead-of-object.snap.md
@@ -1,0 +1,9 @@
+## index.mjs
+
+```mjs
+//#region index.ts
+const hello = "world";
+
+//#endregion
+export { hello };
+```

--- a/tests/__snapshots__/dts-not-enabled-when-no-types-field-and-no-exports-types.snap.md
+++ b/tests/__snapshots__/dts-not-enabled-when-no-types-field-and-no-exports-types.snap.md
@@ -1,0 +1,9 @@
+## index.mjs
+
+```mjs
+//#region index.ts
+const hello = "world";
+
+//#endregion
+export { hello };
+```

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -510,3 +510,27 @@ test('dts not enabled when no types field and no exports.types', async (context)
   expect(outputFiles).not.toContain('index.d.mts')
   expect(outputFiles).toContain('index.mjs')
 })
+
+test('dts not enabled when exports["."] is string instead of object', async (context) => {
+  const files = {
+    'index.ts': `export const hello = "world"`,
+    'package.json': JSON.stringify({
+      name: 'test-pkg',
+      // Note: exports["."] is a string, not an object
+      exports: {
+        '.': './dist/index.js'
+      }
+    })
+  }
+  
+  const { outputFiles } = await testBuild({
+    context,
+    files,
+    options: {
+      dts: undefined, // Allow auto-detection
+    },
+  })
+  
+  expect(outputFiles).not.toContain('index.d.mts')
+  expect(outputFiles).toContain('index.mjs')
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -445,11 +445,11 @@ test('dts enabled when exports.types exists', async (context) => {
       // Note: no "types" field, only exports.types
       exports: {
         types: './dist/index.d.ts',
-        import: './dist/index.js'
-      }
-    })
+        import: './dist/index.js',
+      },
+    }),
   }
-  
+
   const { outputFiles } = await testBuild({
     context,
     files,
@@ -457,7 +457,7 @@ test('dts enabled when exports.types exists', async (context) => {
       dts: undefined, // Allow auto-detection
     },
   })
-  
+
   expect(outputFiles).toContain('index.d.mts')
 })
 
@@ -470,12 +470,12 @@ test('dts enabled when exports["."].types exists', async (context) => {
       exports: {
         '.': {
           types: './dist/index.d.ts',
-          import: './dist/index.js'
-        }
-      }
-    })
+          import: './dist/index.js',
+        },
+      },
+    }),
   }
-  
+
   const { outputFiles } = await testBuild({
     context,
     files,
@@ -483,7 +483,7 @@ test('dts enabled when exports["."].types exists', async (context) => {
       dts: undefined, // Allow auto-detection
     },
   })
-  
+
   expect(outputFiles).toContain('index.d.mts')
 })
 
@@ -494,11 +494,11 @@ test('dts not enabled when no types field and no exports.types', async (context)
       name: 'test-pkg',
       // Note: no "types" field and no exports.types
       exports: {
-        import: './dist/index.js'
-      }
-    })
+        import: './dist/index.js',
+      },
+    }),
   }
-  
+
   const { outputFiles } = await testBuild({
     context,
     files,
@@ -506,7 +506,7 @@ test('dts not enabled when no types field and no exports.types', async (context)
       dts: undefined, // Allow auto-detection
     },
   })
-  
+
   expect(outputFiles).not.toContain('index.d.mts')
   expect(outputFiles).toContain('index.mjs')
 })
@@ -518,11 +518,11 @@ test('dts not enabled when exports["."] is string instead of object', async (con
       name: 'test-pkg',
       // Note: exports["."] is a string, not an object
       exports: {
-        '.': './dist/index.js'
-      }
-    })
+        '.': './dist/index.js',
+      },
+    }),
   }
-  
+
   const { outputFiles } = await testBuild({
     context,
     files,
@@ -530,7 +530,7 @@ test('dts not enabled when exports["."] is string instead of object', async (con
       dts: undefined, // Allow auto-detection
     },
   })
-  
+
   expect(outputFiles).not.toContain('index.d.mts')
   expect(outputFiles).toContain('index.mjs')
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -436,3 +436,77 @@ test('banner and footer option', async (context) => {
   expect(fileMap['index.d.ts']).toContain('// dts banner')
   expect(fileMap['index.d.ts']).toContain('// dts footer')
 })
+
+test('dts enabled when exports.types exists', async (context) => {
+  const files = {
+    'index.ts': `export const hello = "world"`,
+    'package.json': JSON.stringify({
+      name: 'test-pkg',
+      // Note: no "types" field, only exports.types
+      exports: {
+        types: './dist/index.d.ts',
+        import: './dist/index.js'
+      }
+    })
+  }
+  
+  const { outputFiles } = await testBuild({
+    context,
+    files,
+    options: {
+      dts: undefined, // Allow auto-detection
+    },
+  })
+  
+  expect(outputFiles).toContain('index.d.mts')
+})
+
+test('dts enabled when exports["."].types exists', async (context) => {
+  const files = {
+    'index.ts': `export const hello = "world"`,
+    'package.json': JSON.stringify({
+      name: 'test-pkg',
+      // Note: no "types" field, only exports["."].types
+      exports: {
+        '.': {
+          types: './dist/index.d.ts',
+          import: './dist/index.js'
+        }
+      }
+    })
+  }
+  
+  const { outputFiles } = await testBuild({
+    context,
+    files,
+    options: {
+      dts: undefined, // Allow auto-detection
+    },
+  })
+  
+  expect(outputFiles).toContain('index.d.mts')
+})
+
+test('dts not enabled when no types field and no exports.types', async (context) => {
+  const files = {
+    'index.ts': `export const hello = "world"`,
+    'package.json': JSON.stringify({
+      name: 'test-pkg',
+      // Note: no "types" field and no exports.types
+      exports: {
+        import: './dist/index.js'
+      }
+    })
+  }
+  
+  const { outputFiles } = await testBuild({
+    context,
+    files,
+    options: {
+      dts: undefined, // Allow auto-detection
+    },
+  })
+  
+  expect(outputFiles).not.toContain('index.d.mts')
+  expect(outputFiles).toContain('index.mjs')
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR enables automatic dts (declaration file) generation when exports.types or exports["."].types fields are
 present in package.json, extending the existing auto-detection logic that only checked for top-level types and
 typings fields. 
Implementation:
- Added hasExportsTypes() helper function to check for exports.types and exports["."].types
- Modified the dts auto-detection logic in resolveConfig() to include the new check
- Maintained backward compatibility - all existing behavior continues to work

### Linked Issues

Fixes #439 

### Additional context

Created files `tests/__snapshots__/dts-enabled-when-exports-types-exists.snap.md`, `tests/__snapshots__/dts-not-enabled-when-no-types-field-and-no-exports-types.snap.md`, and `tests/__snapshots__/dts-not-enabled-when-exports-is-string-instead-of-object.snap.md`
