### PR TITLE
fix: combine cjs information groups

### DIFF
--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -29,12 +29,14 @@ export async function getBuildOptions(
   format: NormalizedFormat,
   isMultiFormat?: boolean,
   cjsDts: boolean = false,
+  skipReport: boolean = false,
 ): Promise<BuildOptions> {
   const inputOptions = await resolveInputOptions(
     config,
     format,
     cjsDts,
     isMultiFormat,
+    skipReport,
   )
 
   const outputOptions: OutputOptions = await resolveOutputOptions(
@@ -62,6 +64,7 @@ export async function resolveInputOptions(
   format: NormalizedFormat,
   cjsDts: boolean,
   isMultiFormat?: boolean,
+  skipReport: boolean = false,
 ): Promise<InputOptions> {
   const {
     entry,
@@ -128,7 +131,12 @@ export async function resolveInputOptions(
     plugins.push(ShebangPlugin(logger, cwd, name, isMultiFormat))
   }
 
-  if (report && LogLevels[logger.level] >= 3 /* info */) {
+  if (
+    report &&
+    LogLevels[logger.level] >= 3 /* info */ &&
+    !cjsDts &&
+    !skipReport
+  ) {
     plugins.push(ReportPlugin(report, logger, cwd, cjsDts, name, isMultiFormat))
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

  This PR fixes the issue where CJS files were being reported in separate groups when building with both CJS
  format and DTS enabled. Previously, the build output would show CJS files split across multiple reporting
  sections, making it difficult to understand the total size and file count for the CJS build.

  **Changes made:**

  1. **Modified `getBuildOptions` in `src/features/rolldown.ts`** to accept a `skipReport` parameter that
  prevents the ReportPlugin from being added to the initial CJS build when DTS is enabled.
  2. **Updated build logic in `src/index.ts`** to skip reporting for the first CJS build when DTS is enabled, and
   instead manually generate a combined report after both builds complete.
  3. **Extracted reporting logic** from ReportPlugin into a standalone `generateReport` function in
  `src/features/report.ts` to enable manual reporting with combined file data.
  4. **Added conditional logic** to ensure the fix only affects CJS builds with DTS enabled, leaving all other
  build scenarios unchanged

### Linked Issues
  Fixes issue #421
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
