### PR TITLE
docs: fix code example from export to import in React Support section

### DIFF
--- a/docs/recipes/react-support.md
+++ b/docs/recipes/react-support.md
@@ -43,7 +43,7 @@ export const MyButton: React.FC<MyButtonProps> = ({ type }) => {
 And import it in your entry file:
 
 ```ts [index.ts]
-import { MyButton } from './MyButton'
+export { MyButton } from './MyButton'
 ```
 
 ::: warning

--- a/docs/recipes/react-support.md
+++ b/docs/recipes/react-support.md
@@ -40,7 +40,7 @@ export const MyButton: React.FC<MyButtonProps> = ({ type }) => {
 }
 ```
 
-And import it in your entry file:
+And export it in your entry file:
 
 ```ts [index.ts]
 export { MyButton } from './MyButton'

--- a/docs/recipes/react-support.md
+++ b/docs/recipes/react-support.md
@@ -43,7 +43,7 @@ export const MyButton: React.FC<MyButtonProps> = ({ type }) => {
 And import it in your entry file:
 
 ```ts [index.ts]
-export { MyButton } from './MyButton'
+import { MyButton } from './MyButton'
 ```
 
 ::: warning


### PR DESCRIPTION
fixes #446 

This PR fixes a documentation error in the React Support section where the code example incorrectly used export instead of import.

The documentation says "And import it in your entry file:", but the code example incorrectly showed:

```ts
export { MyButton } from './MyButton'
```