### PR TITLE
fix: handle empty string outExtensions

### DIFF
--- a/src/features/output.ts
+++ b/src/features/output.ts
@@ -58,7 +58,7 @@ export function resolveChunkFilename(
     dtsExtension = dts
   }
 
-  jsExtension ||= `.${resolveJsOutputExtension(packageType, format, fixedExtension)}`
+  jsExtension ??= `.${resolveJsOutputExtension(packageType, format, fixedExtension)}`
 
   const suffix = format === 'iife' || format === 'umd' ? `.${format}` : ''
   return [
@@ -77,7 +77,7 @@ function createChunkFilename(
   jsExtension: string,
   dtsExtension?: string,
 ): ChunkFileName {
-  if (!dtsExtension) return `${basename}${jsExtension}`
+  if (dtsExtension === undefined) return `${basename}${jsExtension}`
   return (chunk: PreRenderedChunk) => {
     return `${basename}${chunk.name.endsWith('.d') ? dtsExtension : jsExtension}`
   }

--- a/tests/__snapshots__/custom-extension-with-empty-string.snap.md
+++ b/tests/__snapshots__/custom-extension-with-empty-string.snap.md
@@ -1,0 +1,18 @@
+## index
+
+```
+//#region index.ts
+var custom_extension_with_empty_string_default = 10;
+
+//#endregion
+export { custom_extension_with_empty_string_default as default };
+```
+## index.d
+
+```d
+//#region index.d.ts
+var _default = [0];
+
+//#endregion
+export { _default as default };
+```

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -124,6 +124,26 @@ test('custom extension', async (context) => {
   `)
 })
 
+test('custom extension with empty string', async (context) => {
+  const files = {
+    'index.ts': `export default 10`,
+  }
+  const { outputFiles } = await testBuild({
+    context,
+    files,
+    options: {
+      dts: true,
+      outExtensions: () => ({ js: '', dts: '' }),
+    },
+  })
+  expect(outputFiles).toMatchInlineSnapshot(`
+    [
+      "index",
+      "index.d",
+    ]
+  `)
+})
+
 test('noExternal', async (context) => {
   const files = {
     'index.ts': `export * from 'cac'`,


### PR DESCRIPTION
Fixes #493 

Currently, there is a falsy check for both `jsExtension` and `dtsExtension`. These should instead be explicit checks for `undefined` so an empty string can be used as a custom extension.