### PR TITLE
fix: remove runtime helper check

### DIFF
--- a/docs/options/target.md
+++ b/docs/options/target.md
@@ -75,54 +75,6 @@ You can also pass an array of targets to ensure compatibility across multiple en
 tsdown --target chrome100 --target node20.18
 ```
 
-## Runtime Helpers
-
-When downleveling certain modern JavaScript features, `tsdown` may require runtime helpers provided by the `@oxc-project/runtime` package. For example, transforming `await` expressions into older syntax requires the helper `@oxc-project/runtime/helpers/asyncToGenerator`.
-
-If your target includes features that require these helpers, you may need to install the `@oxc-project/runtime` package in your project:
-
-::: code-group
-
-```sh [npm]
-npm install @oxc-project/runtime
-```
-
-```sh [pnpm]
-pnpm add @oxc-project/runtime
-```
-
-```sh [yarn]
-yarn add @oxc-project/runtime
-```
-
-```sh [bun]
-bun add @oxc-project/runtime
-```
-
-:::
-
-If you want to **inline helper functions** instead of importing them from the runtime package, you can install `@oxc-project/runtime` as a development dependency:
-
-::: code-group
-
-```sh [npm]
-npm install -D @oxc-project/runtime
-```
-
-```sh [pnpm]
-pnpm add -D @oxc-project/runtime
-```
-
-```sh [yarn]
-yarn add -D @oxc-project/runtime
-```
-
-```sh [bun]
-bun add -D @oxc-project/runtime
-```
-
-:::
-
 # CSS Targeting
 
 `tsdown` can also downlevel CSS features to match your specified browser targets. For example, a CSS nesting `&` selector will be flattened if the target is `chrome108` or lower.

--- a/docs/zh-CN/options/target.md
+++ b/docs/zh-CN/options/target.md
@@ -75,54 +75,6 @@ tsdown --target es2020
 tsdown --target chrome100 --target node20.18
 ```
 
-## 运行时辅助工具
-
-在降级某些现代 JavaScript 特性时，`tsdown` 可能需要由 `@oxc-project/runtime` 包提供的运行时辅助工具。例如，将 `await` 表达式转换为旧语法时，需要使用辅助工具 `@oxc-project/runtime/helpers/asyncToGenerator`。
-
-如果您的目标环境包含需要这些辅助工具的特性，您可能需要在项目中安装 `@oxc-project/runtime` 包：
-
-::: code-group
-
-```sh [npm]
-npm install @oxc-project/runtime
-```
-
-```sh [pnpm]
-pnpm add @oxc-project/runtime
-```
-
-```sh [yarn]
-yarn add @oxc-project/runtime
-```
-
-```sh [bun]
-bun add @oxc-project/runtime
-```
-
-:::
-
-如果您希望**内联辅助函数**，而不是从运行时包中导入它们，可以将 `@oxc-project/runtime` 作为开发依赖进行安装：
-
-::: code-group
-
-```sh [npm]
-npm install -D @oxc-project/runtime
-```
-
-```sh [pnpm]
-pnpm add -D @oxc-project/runtime
-```
-
-```sh [yarn]
-yarn add -D @oxc-project/runtime
-```
-
-```sh [bun]
-bun add -D @oxc-project/runtime
-```
-
-:::
-
 # CSS 目标
 
 `tsdown` 也可以将 CSS 特性降级以匹配您指定的浏览器目标。例如，如果目标是 `chrome108` 或更低版本，CSS 嵌套的 `&` 选择器将被展开为平铺结构。

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -15,7 +15,6 @@ import { resolveChunkAddon, resolveChunkFilename } from './output'
 import { ReportPlugin } from './report'
 import { ShebangPlugin } from './shebang'
 import { getShimsInject } from './shims'
-import { RuntimeHelperCheckPlugin } from './target'
 import type {
   BuildOptions,
   InputOptions,
@@ -128,7 +127,6 @@ export async function resolveInputOptions(
     }
     if (target) {
       plugins.push(
-        RuntimeHelperCheckPlugin(logger, target),
         // Use Lightning CSS to handle CSS input. This is a temporary solution
         // until Rolldown supports CSS syntax lowering natively.
         await LightningCSSPlugin({ target }),

--- a/src/features/target.ts
+++ b/src/features/target.ts
@@ -1,9 +1,7 @@
-import { blue } from 'ansis'
 import minVersion from 'semver/ranges/min-version.js'
 import { resolveComma, toArray } from '../utils/general'
 import { generateColor, prettyName, type Logger } from '../utils/logger'
 import type { PackageJson } from 'pkg-types'
-import type { Plugin } from 'rolldown'
 
 export function resolveTarget(
   logger: Logger,
@@ -37,35 +35,4 @@ export function resolvePackageTarget(pkg?: PackageJson): string | undefined {
   if (!nodeMinVersion) return
   if (nodeMinVersion.version === '0.0.0') return
   return `node${nodeMinVersion.version}`
-}
-
-let warned = false
-export function RuntimeHelperCheckPlugin(
-  logger: Logger,
-  targets: string[],
-): Plugin {
-  return {
-    name: 'tsdown:runtime-helper-check',
-    resolveId: {
-      filter: { id: /^@oxc-project\/runtime/ },
-      async handler(id, ...args) {
-        const EXTERNAL = { id, external: true }
-        if (warned) return EXTERNAL
-
-        const resolved = await this.resolve(id, ...args)
-        if (!resolved) {
-          if (!warned) {
-            warned = true
-            logger.warn(
-              `The target environment (${targets.join(', ')}) requires runtime helpers from ${blue`@oxc-project/runtime`}. ` +
-                `Please install it to ensure all necessary polyfills are included.\n` +
-                `For more information, visit: https://tsdown.dev/options/target#runtime-helpers`,
-            )
-          }
-          return EXTERNAL
-        }
-        return resolved
-      },
-    },
-  }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since rolldown v1.0.0-beta.38, `@oxc-project/runtime` is not needed anymore.


> https://github.com/rolldown/rolldown/releases/tag/v1.0.0-beta.38
> 
> Zero dependencies: Helpers embedded directly, no `@oxc-project/runtime` needed

I checked the original issue report https://github.com/rolldown/tsdown/issues/140 and can confirm that `RuntimeHelperCheckPlugin` in tsdown's codebase is not used with the latest rolldown. 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

N/A

### Additional context

N/A

<!-- e.g. is there anything you'd like reviewers to focus on? -->
