### PR TITLE
fix(options): correct Vite alias handling

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -279,7 +279,7 @@ async function resolveConfig(
         )
       }
       if (viteAlias) {
-        alias = viteAlias
+        alias = { ...alias, ...viteAlias }
       }
 
       if (viteUserConfig.plugins) {

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -271,23 +271,19 @@ async function resolveConfig(
       cwd,
     )
     if (viteUserConfig) {
-      // const alias = viteUserConfig.resolve?.alias
-      if ((Array.isArray as (arg: any) => arg is readonly any[])(alias)) {
+      const viteAlias = viteUserConfig.resolve?.alias
+
+      if ((Array.isArray as (arg: any) => arg is readonly any[])(viteAlias)) {
         throw new TypeError(
           'Unsupported resolve.alias in Vite config. Use object instead of array',
         )
       }
+      if (viteAlias) {
+        alias = viteAlias
+      }
 
       if (viteUserConfig.plugins) {
         plugins = [viteUserConfig.plugins as any, plugins]
-      }
-
-      const viteAlias = viteUserConfig.resolve?.alias
-      if (
-        viteAlias &&
-        !(Array.isArray as (arg: any) => arg is readonly any[])(viteAlias)
-      ) {
-        alias = viteAlias
       }
     }
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR ensures that a proper error is displayed when an invalid `resolve.alias` is set in Vite Config.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
