### PR TITLE
fix(logger): correct silent mode to display error messages only

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,7 +12,7 @@ export interface LoggerOptions {
 }
 
 export const LogLevels: Record<LogLevel, number> = {
-  silent: 0,
+  silent: 1,
   error: 1,
   warn: 2,
   info: 3,


### PR DESCRIPTION
### Description

The documentation (https://tsdown.dev/options/silent-mode) states:

“In silent mode, only error messages will be displayed, making it easier to focus on critical issues during the build process.”

However, in practice, error messages were also hidden. This PR fixes that bug.

In addition, I noticed that the `--silent` flag has already been marked as deprecated in the codebase. I’m not sure if my work is still useful, but since the feature still exists, I decided to fix it.

### Linked Issues

Fixes #471

