### PR TITLE
fix(config): clean per-format outDir when using object format

### DIFF
--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -147,7 +147,6 @@ export async function resolveUserConfig(
     (removeNodeProtocol ? 'strip' : false)
 
   outDir = path.resolve(cwd, outDir)
-  clean = resolveClean(clean, outDir, cwd)
 
   const rawEntry = entry
   const [resolvedEntry, resolvedRoot] = await resolveEntry(
@@ -290,12 +289,11 @@ export async function resolveUserConfig(
   }
 
   /// keep-sorted
-  const config: Omit<ResolvedConfig, 'format'> = {
+  const config: Omit<ResolvedConfig, 'clean' | 'format'> = {
     ...userConfig,
     alias,
     attw,
     cjsDefault,
-    clean,
     configDeps,
     copy: publicDir || copy,
     css,
@@ -346,6 +344,9 @@ export async function resolveUserConfig(
   const resolvedConfigs = formats.map((fmt, idx): ResolvedConfig => {
     const once = idx === 0
     const overrides = objectFormat ? format[fmt] : undefined
+    const formatOutDir = overrides?.outDir
+      ? path.resolve(cwd, overrides.outDir)
+      : outDir
     return {
       ...config,
       // only copy once
@@ -354,6 +355,8 @@ export async function resolveUserConfig(
       onSuccess: once ? config.onSuccess : undefined,
       format: normalizeFormat(fmt),
       ...overrides,
+      outDir: formatOutDir,
+      clean: resolveClean(overrides?.clean ?? clean, formatOutDir, cwd),
     }
   })
 

--- a/src/features/exe.ts
+++ b/src/features/exe.ts
@@ -57,7 +57,7 @@ export function validateSea({
   entry,
   logger,
   nameLabel,
-}: Omit<ResolvedConfig, 'format'>): void {
+}: Omit<ResolvedConfig, 'clean' | 'format'>): void {
   if (process.versions.bun || process.versions.deno) {
     throw new Error(
       'The `exe` option is not supported in Bun and Deno environments.',

--- a/tests/clean.test.ts
+++ b/tests/clean.test.ts
@@ -220,6 +220,43 @@ describe('clean', () => {
     expect(oldFileExists).toBe(false)
   })
 
+  test('should clean per-format outDir when using object format', async (context) => {
+    const files = {
+      'index.ts': 'export const hello = "world"',
+    }
+
+    // Create per-format directories and stale files first
+    const testDir = getTestDir(context.task)
+    const esmPath = path.join(testDir, 'esm')
+    const cjsPath = path.join(testDir, 'cjs')
+
+    await mkdir(esmPath, { recursive: true })
+    await mkdir(cjsPath, { recursive: true })
+
+    await writeFile(path.join(esmPath, 'old-esm.js'), 'old esm')
+    await writeFile(path.join(cjsPath, 'old-cjs.js'), 'old cjs')
+
+    // Run build with per-format outDir overrides and clean: true
+    await testBuild({
+      context,
+      files,
+      options: {
+        clean: true,
+        format: {
+          esm: { outDir: 'esm' },
+          cjs: { outDir: 'cjs' },
+        },
+      },
+      snapshot: false,
+    })
+
+    // Verify each per-format outDir was cleaned and new output was produced
+    expect(await fsExists(path.join(esmPath, 'old-esm.js'))).toBe(false)
+    expect(await fsExists(path.join(cjsPath, 'old-cjs.js'))).toBe(false)
+    expect(await fsExists(path.join(esmPath, 'index.mjs'))).toBe(true)
+    expect(await fsExists(path.join(cjsPath, 'index.cjs'))).toBe(true)
+  })
+
   test('should clean files with specific extensions', async (context) => {
     const files = {
       'index.ts': 'export const hello = "world"',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.
-->

- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

With `format: { esm: { outDir: 'esm' }, cjs: { outDir: 'cjs' } }` and `clean: true`, the per-format directories are never cleaned. `resolveClean` runs once against the root `outDir` at `src/config/options.ts:150` and the result is shared across every resolved config via `...config` — per-format `outDir` overrides applied later in the map at L346-358 never make it into that array, so `cleanOutDir` only globs the root directory.

Deferring `resolveClean` into the per-format loop gives each config its own `clean` array derived from that format's effective `outDir`. A user-supplied per-format `clean` (`overrides?.clean`) wins over the top-level one, and `overrides.outDir` is resolved to an absolute path in the same place to keep override semantics consistent with the root `outDir`.



### Linked Issues
fixes: #843

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The new test in `tests/clean.test.ts` fails without the fix and passes with it — it checks that stale files in each per-format `outDir` get removed and that the build still writes new output into the same directories. All existing `clean` tests still pass; if you don't use per-format `outDir` overrides, nothing changes — each resolved config still gets `resolveClean(true, outDir, cwd)` against the shared root `outDir` and produces the same `[slash(outDir)]` as before.

`validateSea` never reads `clean`, so its parameter type is narrowed to `Omit<ResolvedConfig, 'clean' | 'format'>`. This keeps the intermediate `config` object type accurate once `clean` moves out.
