### PR TITLE
feat: add `maxParallel` option to limit workspace build concurrency

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -49,22 +49,9 @@ export async function build(
   return buildWithConfigs(configs, configDeps, () => build(inlineConfig))
 }
 
-function normalizeMaxParallel(
-  maxParallel: number | undefined,
-): number | undefined {
-  if (maxParallel == null) return undefined
-  if (!Number.isInteger(maxParallel) || maxParallel < 1)
-    throw new TypeError('`maxParallel` must be a positive integer.')
-  return maxParallel
-}
-
 function resolveMaxParallel(configs: ResolvedConfig[]): number | undefined {
   const values = [
-    ...new Set(
-      configs
-        .map((config) => normalizeMaxParallel(config.maxParallel))
-        .filter((value) => value != null),
-    ),
+    ...new Set(configs.map((c) => c.maxParallel).filter((v) => v != null)),
   ]
   if (values.length > 1)
     throw new TypeError(

--- a/src/build.ts
+++ b/src/build.ts
@@ -69,6 +69,23 @@ async function mapWithConcurrency<T, R>(
   return results
 }
 
+function resolveMaxParallel(configs: ResolvedConfig[]): number | undefined {
+  const configured = configs
+    .map((config) => config.maxParallel)
+    .filter((value): value is number => value != null)
+
+  if (configured.length === 0) return undefined
+
+  const resolved = Math.min(...configured)
+  if (new Set(configured).size > 1) {
+    globalLogger.warn(
+      `Conflicting \`maxParallel\` values detected (${configured.join(', ')}). Using the smallest value: ${resolved}.`,
+    )
+  }
+
+  return resolved
+}
+
 /**
  * Build with `ResolvedConfigs`.
  *
@@ -104,7 +121,7 @@ export async function buildWithConfigs(
   }
 
   globalLogger.info('Build start')
-  const { maxParallel } = configs[0] ?? {}
+  const maxParallel = resolveMaxParallel(configs)
   const buildConfig = (options: ResolvedConfig) => {
     const isDualFormat = options.pkg
       ? configChunksByPkg[options.pkg.packageJsonPath].formats.size > 1

--- a/src/build.ts
+++ b/src/build.ts
@@ -49,17 +49,6 @@ export async function build(
   return buildWithConfigs(configs, configDeps, () => build(inlineConfig))
 }
 
-function resolveMaxParallel(configs: ResolvedConfig[]): number | undefined {
-  const values = [
-    ...new Set(configs.map((c) => c.maxParallel).filter((v) => v != null)),
-  ]
-  if (values.length > 1)
-    throw new TypeError(
-      '`maxParallel` must be the same across all workspace configs.',
-    )
-  return values[0]
-}
-
 async function mapWithConcurrency<T, R>(
   items: T[],
   limit: number,
@@ -115,7 +104,7 @@ export async function buildWithConfigs(
   }
 
   globalLogger.info('Build start')
-  const maxParallel = resolveMaxParallel(configs)
+  const { maxParallel } = configs[0] ?? {}
   const buildConfig = (options: ResolvedConfig) => {
     const isDualFormat = options.pkg
       ? configChunksByPkg[options.pkg.packageJsonPath].formats.size > 1

--- a/src/build.ts
+++ b/src/build.ts
@@ -49,6 +49,50 @@ export async function build(
   return buildWithConfigs(configs, configDeps, () => build(inlineConfig))
 }
 
+function normalizeMaxParallel(
+  maxParallel: number | undefined,
+): number | undefined {
+  if (maxParallel == null) return undefined
+  if (!Number.isInteger(maxParallel) || maxParallel < 1)
+    throw new TypeError('`maxParallel` must be a positive integer.')
+  return maxParallel
+}
+
+function resolveMaxParallel(configs: ResolvedConfig[]): number | undefined {
+  const values = [
+    ...new Set(
+      configs
+        .map((config) => normalizeMaxParallel(config.maxParallel))
+        .filter((value) => value != null),
+    ),
+  ]
+  if (values.length > 1)
+    throw new TypeError(
+      '`maxParallel` must be the same across all workspace configs.',
+    )
+  return values[0]
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return []
+  const results: R[] = Array.from({ length: items.length })
+  let nextIndex = 0
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      results[index] = await mapper(items[index], index)
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  )
+  return results
+}
+
 /**
  * Build with `ResolvedConfigs`.
  *
@@ -84,21 +128,16 @@ export async function buildWithConfigs(
   }
 
   globalLogger.info('Build start')
-  const bundles = await Promise.all(
-    configs.map((options) => {
-      const isDualFormat = options.pkg
-        ? configChunksByPkg[options.pkg.packageJsonPath].formats.size > 1
-        : true
-      return buildSingle(
-        options,
-        configDeps,
-        isDualFormat,
-        clean,
-        restart,
-        done,
-      )
-    }),
-  )
+  const maxParallel = resolveMaxParallel(configs)
+  const buildConfig = (options: ResolvedConfig) => {
+    const isDualFormat = options.pkg
+      ? configChunksByPkg[options.pkg.packageJsonPath].formats.size > 1
+      : true
+    return buildSingle(options, configDeps, isDualFormat, clean, restart, done)
+  }
+  const bundles = maxParallel
+    ? await mapWithConcurrency(configs, maxParallel, buildConfig)
+    : await Promise.all(configs.map(buildConfig))
 
   const firstDevtoolsConfig = configs.find(
     (config) => config.devtools && config.devtools.ui,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,10 @@ cli
   .option('--exe', 'Bundle as executable')
   .option('-W, --workspace [dir]', 'Enable workspace mode')
   .option(
+    '--max-parallel <number>',
+    'Maximum number of workspace builds to run in parallel',
+  )
+  .option(
     '-F, --filter <pattern>',
     'Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name',
   )
@@ -88,6 +92,7 @@ cli
     )
     const { build } = await import('./build.ts')
     if (input.length > 0) flags.entry = input
+    if (flags.maxParallel != null) flags.maxParallel = Number(flags.maxParallel)
     await build(flags)
   })
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,6 @@ cli
     )
     const { build } = await import('./build.ts')
     if (input.length > 0) flags.entry = input
-    if (flags.maxParallel != null) flags.maxParallel = Number(flags.maxParallel)
     await build(flags)
   })
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ cli
   .option('-W, --workspace [dir]', 'Enable workspace mode')
   .option(
     '--max-parallel <number>',
-    'Maximum number of workspace builds to run in parallel',
+    'Maximum number of config builds to run in parallel',
   )
   .option(
     '-F, --filter <pattern>',

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -333,6 +333,7 @@ export async function resolveUserConfig(
     hash,
     ignoreWatch,
     logger,
+    maxParallel,
     name,
     nameLabel,
     nodeProtocol,

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -107,6 +107,7 @@ export async function resolveUserConfig(
     devtools = false,
     write = true,
     exe = false,
+    maxParallel,
   } = userConfig
 
   const pkg = await readPackageJson(cwd)
@@ -128,6 +129,13 @@ export async function resolveUserConfig(
 
   if (typeof bundle === 'boolean') {
     logger.warn('`bundle` option is deprecated. Use `unbundle` instead.')
+  }
+
+  if (
+    maxParallel != null &&
+    (!Number.isInteger(maxParallel) || maxParallel < 1)
+  ) {
+    throw new TypeError('`maxParallel` must be a positive integer.')
   }
 
   if (removeNodeProtocol) {

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -107,8 +107,11 @@ export async function resolveUserConfig(
     devtools = false,
     write = true,
     exe = false,
-    maxParallel,
+    maxParallel: maxParallelRaw,
   } = userConfig
+
+  const maxParallel =
+    maxParallelRaw == null ? undefined : Number(maxParallelRaw)
 
   const pkg = await readPackageJson(cwd)
   if (workspace) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -685,6 +685,19 @@ export interface UserConfig {
    * This allows you to build multiple packages in a monorepo.
    */
   workspace?: Workspace | Arrayable<string> | true
+
+  /**
+   * Limit how many workspace builds can run at the same time.
+   *
+   * This is useful when each package starts expensive child processes during
+   * build (e.g. `tsgo` via `dts.tsgo: true`). Without a limit, all workspace
+   * packages start building concurrently, which can spawn a large number of
+   * subprocesses and exhaust system resources.
+   *
+   * When set to a positive integer, at most that many builds run in parallel.
+   * When omitted or `undefined`, all builds run concurrently (existing behavior).
+   */
+  maxParallel?: number
 }
 
 export interface InlineConfig extends UserConfig {
@@ -748,6 +761,7 @@ export type ResolvedConfig = Overwrite<
     | 'footer'
     | 'checks'
     | 'css'
+    | 'maxParallel'
   >,
   {
     /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -687,11 +687,11 @@ export interface UserConfig {
   workspace?: Workspace | Arrayable<string> | true
 
   /**
-   * Limit how many workspace builds can run at the same time.
+   * Limit how many config builds can run at the same time.
    *
-   * This is useful when each package starts expensive child processes during
-   * build (e.g. `tsgo` via `dts.tsgo: true`). Without a limit, all workspace
-   * packages start building concurrently, which can spawn a large number of
+   * This is especially useful in workspace mode where each package can start
+   * expensive child processes (e.g. `tsgo` via `dts.tsgo: true`). Without a
+   * limit, all configs start building concurrently, which can spawn many
    * subprocesses and exhaust system resources.
    *
    * When set to a positive integer, at most that many builds run in parallel.

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -322,4 +322,54 @@ export const loadDynamic = () => import('./dynamic')`,
     expect(fileMap['index.mjs']).toContain('polyfill-uuid')
     expect(fileMap['index.mjs']).not.toMatch(/from ['"]crypto['"]/)
   })
+
+  test('#929', async (context) => {
+    let inFlight = 0
+    let peak = 0
+
+    await testBuild({
+      context,
+      snapshot: false,
+      files: {
+        'package.json': JSON.stringify({
+          name: 'issue-929',
+          private: true,
+        }),
+        'packages/a/package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+        }),
+        'packages/a/index.ts': 'export const a = 1',
+        'packages/b/package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+        }),
+        'packages/b/index.ts': 'export const b = 1',
+        'packages/c/package.json': JSON.stringify({
+          name: 'c',
+          version: '1.0.0',
+        }),
+        'packages/c/index.ts': 'export const c = 1',
+        'packages/d/package.json': JSON.stringify({
+          name: 'd',
+          version: '1.0.0',
+        }),
+        'packages/d/index.ts': 'export const d = 1',
+      },
+      options: {
+        workspace: 'packages/*',
+        maxParallel: 2,
+        hooks: {
+          'build:prepare': async () => {
+            inFlight++
+            peak = Math.max(peak, inFlight)
+            await new Promise((resolve) => setTimeout(resolve, 50))
+            inFlight--
+          },
+        },
+      },
+    })
+
+    expect(peak).toBeLessThanOrEqual(2)
+  })
 })


### PR DESCRIPTION
Fixes #929.

## Problem

When using `workspace` mode with `dts.tsgo: true`, `buildWithConfigs` starts all package builds concurrently via `Promise.all()`. Each package spawns a `tsgo` subprocess, so with 64 workspace packages you can end up with 64 concurrent native processes — exhausting CPU/memory and crashing macOS.

## Solution

Add a `maxParallel` option that limits how many workspace builds run at the same time. When set, a simple worker-pool (`mapWithConcurrency`) is used instead of `Promise.all()`. When omitted, existing unbounded concurrent behavior is preserved.

## Changes

- **`src/config/types.ts`**: Add `maxParallel?: number` to `UserConfig`; add it to the `MarkPartial` keys so it stays optional in `ResolvedConfig`
- **`src/cli.ts`**: Add `--max-parallel <number>` CLI flag with numeric coercion
- **`src/build.ts`**: Add `normalizeMaxParallel`, `resolveMaxParallel`, and `mapWithConcurrency` helpers; update `buildWithConfigs` to use the pool when `maxParallel` is set

## Usage

```ts
// tsdown.config.ts
export default {
  workspace: 'packages/*',
  maxParallel: 4,  // at most 4 package builds run at the same time
  dts: { tsgo: true },
}
```

Or via CLI:
```sh
tsdown --workspace packages/* --max-parallel 4
```

## Verification

- `pnpm typecheck` ✅
- `pnpm test run` ✅ (446 passed, 4 expected fail, 4 skipped)
- `pnpm lint` ✅
