### PR TITLE
fix: bundle CSS from external dependencies instead of externalizing

### DIFF
--- a/src/features/deps.ts
+++ b/src/features/deps.ts
@@ -3,7 +3,7 @@ import { isBuiltin } from 'node:module'
 import path from 'node:path'
 import { blue, underline, yellow } from 'ansis'
 import { createDebug } from 'obug'
-import { RE_DTS, RE_NODE_MODULES } from 'rolldown-plugin-dts/internal'
+import { RE_CSS, RE_DTS, RE_NODE_MODULES } from 'rolldown-plugin-dts/internal'
 import { and, id, importerId, include } from 'rolldown/filter'
 import {
   matchPattern,
@@ -328,6 +328,12 @@ export function DepsPlugin(
     const isDts = importer ? RE_DTS.test(importer) : false
     const alwaysBundle = (isDts && dts?.alwaysBundle) || jsAlwaysBundle
     if (alwaysBundle?.(id, importer)) {
+      return 'no-external'
+    }
+
+    // CSS files must always be bundled so the CSS plugin can process them
+    const cssCheckId = resolved?.id || id
+    if (RE_CSS.test(cssCheckId.split('?', 1)[0])) {
       return 'no-external'
     }
 

--- a/tests/__snapshots__/css/external-dependency-CSS-is-bundled-via-JS-import.snap.md
+++ b/tests/__snapshots__/css/external-dependency-CSS-is-bundled-via-JS-import.snap.md
@@ -1,0 +1,18 @@
+## index.mjs
+
+```mjs
+//#region index.ts
+const foo = "bar";
+//#endregion
+export { foo };
+
+```
+
+## style.css
+
+```css
+.lib-component {
+  color: green;
+}
+
+```

--- a/tests/__snapshots__/css/external-dependency-CSS-is-bundled-via-JS-inline-import.snap.md
+++ b/tests/__snapshots__/css/external-dependency-CSS-is-bundled-via-JS-inline-import.snap.md
@@ -1,0 +1,9 @@
+## index.mjs
+
+```mjs
+//#region node_modules/my-lib/styles/main.css?inline
+var main_default = ".lib-inline {\n  color: #00f;\n}\n";
+//#endregion
+export { main_default as style };
+
+```

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -1689,4 +1689,41 @@ describe('css', () => {
       expect(css).toContain('.design-system-default')
     })
   })
+
+  test('external dependency CSS is bundled via JS import', async (context) => {
+    const { fileMap, outputFiles } = await testBuild({
+      context,
+      files: {
+        'index.ts': `import 'my-lib/styles/main.css';\nexport const foo = 'bar';`,
+        'node_modules/my-lib/styles/main.css': `.lib-component { color: green }`,
+        'node_modules/my-lib/package.json': JSON.stringify({
+          name: 'my-lib',
+          version: '1.0.0',
+        }),
+        'package.json': JSON.stringify({
+          dependencies: { 'my-lib': '^1.0.0' },
+        }),
+      },
+    })
+    expect(outputFiles).toContain('style.css')
+    expect(fileMap['style.css']).toContain('.lib-component')
+  })
+
+  test('external dependency CSS is bundled via JS inline import', async (context) => {
+    const { fileMap } = await testBuild({
+      context,
+      files: {
+        'index.ts': `import style from 'my-lib/styles/main.css?inline';\nexport { style };`,
+        'node_modules/my-lib/styles/main.css': `.lib-inline { color: blue }`,
+        'node_modules/my-lib/package.json': JSON.stringify({
+          name: 'my-lib',
+          version: '1.0.0',
+        }),
+        'package.json': JSON.stringify({
+          dependencies: { 'my-lib': '^1.0.0' },
+        }),
+      },
+    })
+    expect(fileMap['index.mjs']).toContain('.lib-inline')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #959

CSS files imported via JS/TS from production dependencies (listed in `dependencies`, `peerDependencies`, or `optionalDependencies`) were being marked as external by the deps plugin, which prevented the CSS plugin from processing them into the output bundle.

This affected both regular CSS imports and `?inline` CSS imports:
- `import 'jodit/es2021/jodit.css'` — CSS not included in output `style.css`
- `import style from 'jodit/es2021/jodit.css?inline'` — CSS not inlined as string

**Root cause:** `externalStrategy()` in `src/features/deps.ts` checked if an import's package name matched a production dependency and externalized it unconditionally. CSS files need to be bundled so the CSS plugin can process them.

**Fix:** Added a guard in `externalStrategy()` that returns `'no-external'` for CSS file imports (`.css`, `.scss`, `.sass`, `.less`, `.styl`, `.stylus`), stripping any query string (e.g. `?inline`) before testing. This runs after the `alwaysBundle` check but before the dependency externalization checks.

## Test plan

- [x] Added test: external dependency CSS is bundled via JS `import`
- [x] Added test: external dependency CSS is bundled via JS `?inline` import
- [x] All existing CSS tests pass (100 passed + 3 expected fail)
- [x] All existing deps tests pass (15 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)