### PR TITLE
fix(css): generate source maps to avoid `SOURCEMAP_BROKEN` warning

### DIFF
--- a/packages/css/src/lightningcss.test.ts
+++ b/packages/css/src/lightningcss.test.ts
@@ -1,6 +1,9 @@
 import { browserslistToTargets } from 'lightningcss'
 import { expect, test } from 'vitest'
-import { esbuildTargetToLightningCSS } from './lightningcss.ts'
+import {
+  esbuildTargetToLightningCSS,
+  transformWithLightningCSS,
+} from './lightningcss.ts'
 
 test('esbuildTargetToLightningCSS', () => {
   const expected = browserslistToTargets([
@@ -27,4 +30,30 @@ test('esbuildTargetToLightningCSS', () => {
     }
   `)
   expect(actual).toEqual(expected)
+})
+
+test('transformWithLightningCSS returns a source map when requested', async () => {
+  const result = await transformWithLightningCSS(
+    'body { color: red }',
+    'x.css',
+    {
+      minify: true,
+      sourceMap: true,
+    },
+  )
+  expect(result.map).toBeTypeOf('string')
+  const map = JSON.parse(result.map!)
+  expect(map.version).toBe(3)
+  expect(map.mappings).toBeTruthy()
+})
+
+test('transformWithLightningCSS omits the map by default', async () => {
+  const result = await transformWithLightningCSS(
+    'body { color: red }',
+    'x.css',
+    {
+      minify: true,
+    },
+  )
+  expect(result.map).toBeUndefined()
 })

--- a/packages/css/src/lightningcss.ts
+++ b/packages/css/src/lightningcss.ts
@@ -15,10 +15,12 @@ export interface TransformCssOptions {
   lightningcss?: LightningCSSOptions
   minify?: boolean
   cssModules?: boolean | CSSModulesConfig
+  sourceMap?: boolean
 }
 
 export interface TransformCssResult {
   code: string
+  map?: string
   modules?: Record<string, string>
 }
 

--- a/packages/css/src/lightningcss.ts
+++ b/packages/css/src/lightningcss.ts
@@ -16,6 +16,7 @@ export interface TransformCssOptions {
   minify?: boolean
   cssModules?: boolean | CSSModulesConfig
   sourceMap?: boolean
+  inputSourceMap?: string
 }
 
 export interface TransformCssResult {
@@ -30,12 +31,14 @@ export interface BundleCssOptions {
   minify?: boolean
   cssModules?: boolean | CSSModulesConfig
   preprocessorOptions?: PreprocessorOptions
+  sourceMap?: boolean
   logger: Logger
 }
 
 export interface BundleCssResult {
   code: string
   deps: string[]
+  map?: string
   modules?: Record<string, string>
 }
 
@@ -64,10 +67,13 @@ export async function transformWithLightningCSS(
     targets,
     minify: options.minify,
     cssModules: options.cssModules,
+    sourceMap: options.sourceMap,
+    inputSourceMap: options.inputSourceMap,
   })
 
   return {
     code: decoder.decode(result.code),
+    map: result.map ? decoder.decode(result.map) : undefined,
     modules: result.exports
       ? extractLightningCssModuleExports(result.exports)
       : undefined,
@@ -92,6 +98,7 @@ export async function bundleWithLightningCSS(
     targets,
     minify: options.minify,
     cssModules: options.cssModules,
+    sourceMap: options.sourceMap,
     resolver: {
       async read(filePath: string) {
         let fileCode: string
@@ -129,8 +136,9 @@ export async function bundleWithLightningCSS(
   })
 
   return {
-    code: new TextDecoder().decode(result.code),
+    code: decoder.decode(result.code),
     deps,
+    map: result.map ? decoder.decode(result.map) : undefined,
     modules: result.exports
       ? extractLightningCssModuleExports(result.exports)
       : undefined,

--- a/packages/css/src/plugin.ts
+++ b/packages/css/src/plugin.ts
@@ -34,6 +34,7 @@ interface CssPluginConfig {
   css: ResolvedCssOptions
   cwd: string
   target?: string[]
+  sourceMap: boolean
 }
 
 interface CssPluginResult {
@@ -59,6 +60,7 @@ export function CssPlugin(
     css: resolveCssOptions(config.css, config.target, config.unbundle),
     cwd: config.cwd,
     target: config.target,
+    sourceMap: Boolean(config.sourcemap),
   }
   const styles: CssStyles = new Map()
   const modulesMap = new Map<string, Record<string, string>>()
@@ -119,6 +121,7 @@ export function CssPlugin(
 
         const deps: string[] = []
         let modules: Record<string, string> | undefined
+        let map: string | undefined
 
         if (cssConfig.css.transformer === 'lightningcss') {
           const result = await processWithLightningCSS(
@@ -132,6 +135,7 @@ export function CssPlugin(
           )
           code = result.code
           modules = result.modules
+          map = result.map
         } else {
           const result = await processWithPostCSS(
             code,
@@ -143,6 +147,7 @@ export function CssPlugin(
           )
           code = result.code
           modules = result.modules
+          map = result.map
         }
 
         for (const dep of deps) {
@@ -170,7 +175,9 @@ export function CssPlugin(
 
         // Return compiled CSS without converting to JS.
         // User plugins can still transform this CSS (e.g. Vue scoped styles).
-        return { code }
+        // `map` is `null` when no real map is available (e.g. no transform ran),
+        // which tells Rolldown the transform has no sourcemap instead of warning.
+        return { code, map: map ?? null }
       },
     },
   }
@@ -189,9 +196,13 @@ export function CssPlugin(
         const isInline = RE_INLINE.test(id)
         const modules = modulesMap.get(id)
 
+        // CSS is rewritten into a JS module here; there is no meaningful
+        // CSS-to-JS sourcemap, so return `map: null` to silence Rolldown's
+        // SOURCEMAP_BROKEN warning without claiming an incorrect map.
         if (isInline) {
           return {
             code: `export default ${JSON.stringify(code)};`,
+            map: null,
             moduleSideEffects: false,
             moduleType: 'js',
           }
@@ -204,6 +215,7 @@ export function CssPlugin(
         if (modules) {
           return {
             code: modulesToEsm(modules),
+            map: null,
             moduleSideEffects: false,
             moduleType: 'js',
           }
@@ -211,6 +223,7 @@ export function CssPlugin(
 
         return {
           code: '',
+          map: null,
           moduleSideEffects: 'no-treeshake',
           moduleType: 'js',
         }
@@ -322,6 +335,7 @@ export function CssPlugin(
 
 interface ProcessResult {
   code: string
+  map?: string
   modules?: Record<string, string>
 }
 
@@ -380,6 +394,7 @@ async function processWithLightningCSS(
       lightningcss: config.css.lightningcss,
       minify: config.css.minify,
       cssModules,
+      sourceMap: config.sourceMap,
     })
   }
 
@@ -391,6 +406,7 @@ async function processWithLightningCSS(
       lightningcss: config.css.lightningcss,
       minify: config.css.minify,
       cssModules,
+      sourceMap: config.sourceMap,
     })
   }
 
@@ -403,12 +419,17 @@ async function processWithLightningCSS(
         minify: config.css.minify,
         cssModules,
         preprocessorOptions: config.css.preprocessorOptions,
+        sourceMap: config.sourceMap,
         logger,
       },
       code,
     )
     deps.push(...bundleResult.deps)
-    return { code: bundleResult.code, modules: bundleResult.modules }
+    return {
+      code: bundleResult.code,
+      map: bundleResult.map,
+      modules: bundleResult.modules,
+    }
   }
 
   return { code: '' }
@@ -446,6 +467,7 @@ async function processWithPostCSS(
     config.cwd,
     needInlineImport,
     isModule ? { isModule: true, config: modulesConfig } : undefined,
+    config.sourceMap,
   )
   code = postcssResult.code
   deps.push(...postcssResult.deps)
@@ -454,9 +476,17 @@ async function processWithPostCSS(
     target: config.css.target,
     lightningcss: config.css.lightningcss,
     minify: config.css.minify,
+    sourceMap: config.sourceMap,
+    inputSourceMap: postcssResult.map,
   })
 
-  return { code: transformResult.code, modules: postcssResult.modules }
+  // When LightningCSS skips its transform (no targets/minify), it returns no
+  // map; fall back to the PostCSS map so the chain still has one.
+  return {
+    code: transformResult.code,
+    map: transformResult.map ?? postcssResult.map,
+    modules: postcssResult.modules,
+  }
 }
 
 function isEmptyChunkCode(code: string): boolean {

--- a/packages/css/src/postcss.ts
+++ b/packages/css/src/postcss.ts
@@ -9,6 +9,7 @@ interface PostCSSConfigResult {
 interface PostCSSProcessResult {
   code: string
   deps: string[]
+  map?: string
   modules?: Record<string, string>
 }
 
@@ -70,6 +71,7 @@ export async function processWithPostCSS(
   cwd: string,
   injectImport?: boolean,
   modulesOptions?: PostCSSModulesOptions,
+  sourceMap?: boolean,
 ): Promise<PostCSSProcessResult> {
   const config = await resolvePostCSSConfig(postcssOption, cwd)
 
@@ -117,6 +119,9 @@ export async function processWithPostCSS(
     ...config?.options,
     from: filename,
     to: filename,
+    map: sourceMap
+      ? { inline: false, annotation: false, prev: false }
+      : undefined,
   })
 
   const deps: string[] = []
@@ -131,5 +136,5 @@ export async function processWithPostCSS(
     }
   }
 
-  return { code: result.css, deps, modules }
+  return { code: result.css, deps, map: result.map?.toString(), modules }
 }

--- a/tests/__snapshots__/sourcemap/css-modules-do-not-warn-SOURCEMAP_BROKEN.snap.md
+++ b/tests/__snapshots__/sourcemap/css-modules-do-not-warn-SOURCEMAP_BROKEN.snap.md
@@ -1,0 +1,25 @@
+## index.mjs
+
+```mjs
+//#region app.module.css
+var app_module_default = { "title": "mod_title" };
+//#endregion
+export { app_module_default as styles };
+
+//# sourceMappingURL=index.mjs.map
+```
+
+## index.mjs.map
+
+```map
+{"version":3,"file":"index.mjs","names":[],"sources":["../app.module.css"],"sourcesContent":[".title { color: red }"],"mappings":""}
+```
+
+## style.css
+
+```css
+.mod_title {
+  color: red;
+}
+
+```

--- a/tests/__snapshots__/sourcemap/inline-css-does-not-warn-SOURCEMAP_BROKEN.snap.md
+++ b/tests/__snapshots__/sourcemap/inline-css-does-not-warn-SOURCEMAP_BROKEN.snap.md
@@ -1,0 +1,17 @@
+## index.mjs
+
+```mjs
+//#endregion
+//#region index.ts
+console.log(".foo {\n  color: red;\n}\n");
+//#endregion
+export {};
+
+//# sourceMappingURL=index.mjs.map
+```
+
+## index.mjs.map
+
+```map
+{"version":3,"file":"index.mjs","names":["css"],"sources":["../foo.css?inline","../index.ts"],"sourcesContent":[".foo { color: red }","import css from './foo.css?inline'\nconsole.log(css)"],"mappings":";;ACCA,QAAQ,IAAIA,4BAAG"}
+```

--- a/tests/__snapshots__/sourcemap/lightningcss-does-not-warn-SOURCEMAP_BROKEN.snap.md
+++ b/tests/__snapshots__/sourcemap/lightningcss-does-not-warn-SOURCEMAP_BROKEN.snap.md
@@ -1,0 +1,25 @@
+## index.mjs
+
+```mjs
+//#region index.ts
+const value = 42;
+//#endregion
+export { value };
+
+//# sourceMappingURL=index.mjs.map
+```
+
+## index.mjs.map
+
+```map
+{"version":3,"file":"index.mjs","names":[],"sources":["../index.ts"],"sourcesContent":["import './foo.css'\nexport const value = 42"],"mappings":";AACA,MAAa,QAAQ"}
+```
+
+## style.css
+
+```css
+body {
+  color: red;
+}
+
+```

--- a/tests/__snapshots__/sourcemap/postcss-does-not-warn-SOURCEMAP_BROKEN.snap.md
+++ b/tests/__snapshots__/sourcemap/postcss-does-not-warn-SOURCEMAP_BROKEN.snap.md
@@ -1,0 +1,23 @@
+## index.mjs
+
+```mjs
+//#region index.ts
+const value = 42;
+//#endregion
+export { value };
+
+//# sourceMappingURL=index.mjs.map
+```
+
+## index.mjs.map
+
+```map
+{"version":3,"file":"index.mjs","names":[],"sources":["../index.ts"],"sourcesContent":["import './style.css'\nexport const value = 42"],"mappings":";AACA,MAAa,QAAQ"}
+```
+
+## style.css
+
+```css
+.foo { color: red }
+
+```

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -1689,4 +1689,73 @@ describe('css', () => {
       expect(css).toContain('.design-system-default')
     })
   })
+
+  describe('sourcemap', () => {
+    function sourcemapWarnings(warnings: { code?: string }[]) {
+      return warnings.filter((warning) => warning.code === 'SOURCEMAP_BROKEN')
+    }
+
+    test('lightningcss does not warn SOURCEMAP_BROKEN', async (context) => {
+      const { outputFiles, warnings } = await testBuild({
+        context,
+        files: {
+          'index.ts': `import './foo.css'\nexport const value = 42`,
+          'foo.css': `body { color: red }`,
+        },
+        options: { sourcemap: true },
+      })
+      expect(sourcemapWarnings(warnings)).toEqual([])
+      expect(outputFiles).toContain('index.mjs.map')
+    })
+
+    test('postcss does not warn SOURCEMAP_BROKEN', async (context) => {
+      const { outputFiles, warnings } = await testBuild({
+        context,
+        files: {
+          'index.ts': `import './style.css'\nexport const value = 42`,
+          'style.css': `.foo { color: red }`,
+        },
+        options: {
+          sourcemap: true,
+          css: {
+            transformer: 'postcss',
+            postcss: {
+              plugins: [{ postcssPlugin: 'noop', Once() {} }],
+            },
+          },
+        },
+      })
+      expect(sourcemapWarnings(warnings)).toEqual([])
+      expect(outputFiles).toContain('index.mjs.map')
+    })
+
+    test('css modules do not warn SOURCEMAP_BROKEN', async (context) => {
+      const { outputFiles, warnings } = await testBuild({
+        context,
+        files: {
+          'index.ts': `export { default as styles } from './app.module.css'`,
+          'app.module.css': `.title { color: red }`,
+        },
+        options: {
+          sourcemap: true,
+          css: { modules: { generateScopedName: 'mod_[local]' } },
+        },
+      })
+      expect(sourcemapWarnings(warnings)).toEqual([])
+      expect(outputFiles).toContain('index.mjs.map')
+    })
+
+    test('inline css does not warn SOURCEMAP_BROKEN', async (context) => {
+      const { outputFiles, warnings } = await testBuild({
+        context,
+        files: {
+          'index.ts': `import css from './foo.css?inline'\nconsole.log(css)`,
+          'foo.css': `.foo { color: red }`,
+        },
+        options: { sourcemap: true },
+      })
+      expect(sourcemapWarnings(warnings)).toEqual([])
+      expect(outputFiles).toContain('index.mjs.map')
+    })
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

  > Written by Opus 4.8

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Make LightningCSS/PostCSS emit real source maps and stop tripping Rolldown's `SOURCEMAP_BROKEN` warning.

### Linked Issues

Closes https://github.com/rolldown/tsdown/issues/977


### Additional context

Tested manually with https://github.com/issueset/tsdown-css-sourcemap-warn and pkg-pr-new prerelease version to verify.
<!-- e.g. is there anything you'd like reviewers to focus on? -->
