### PR TITLE
fix(shims): don't emit esm shim banner in cjs output for unbundle

### DIFF
--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -27,7 +27,7 @@ import { NodeProtocolPlugin } from './node-protocol.ts'
 import { resolveChunkAddon, resolveChunkFilename } from './output.ts'
 import { ReportPlugin } from './report.ts'
 import { ShebangPlugin } from './shebang.ts'
-import { getShimsInject, shimsDefine, shimsPlugin } from './shims.ts'
+import { getShims } from './shims.ts'
 import { WatchPlugin } from './watch.ts'
 import type {
   DtsOptions,
@@ -107,7 +107,6 @@ async function resolveInputOptions(
     target,
     treeshake,
     tsconfig,
-    unbundle,
     unused,
     watch,
   } = config
@@ -205,15 +204,11 @@ async function resolveInputOptions(
 
   let inject: TransformOptions['inject']
   if (shims && !cjsDts) {
-    if (unbundle) {
-      // shimsPlugin's banner is ESM syntax so gate it like
-      // getShimsInject or it ends up in in cjs output
-      if (format === 'es' && platform === 'node') {
-        define = { ...define, ...shimsDefine }
-        plugins.push(shimsPlugin)
-      }
-    } else {
-      inject = getShimsInject(format, platform)
+    const shims = getShims(config)
+    inject = shims.inject
+    define = { ...define, ...shims.define }
+    if (shims.plugin) {
+      plugins.push(shims.plugin)
     }
   }
 

--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -206,8 +206,12 @@ async function resolveInputOptions(
   let inject: TransformOptions['inject']
   if (shims && !cjsDts) {
     if (unbundle) {
-      define = { ...define, ...shimsDefine }
-      plugins.push(shimsPlugin)
+      // shimsPlugin's banner is ESM syntax so gate it like
+      // getShimsInject or it ends up in in cjs output
+      if (format === 'es' && platform === 'node') {
+        define = { ...define, ...shimsDefine }
+        plugins.push(shimsPlugin)
+      }
     } else {
       inject = getShimsInject(format, platform)
     }

--- a/src/features/shims.ts
+++ b/src/features/shims.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { NormalizedFormat, ResolvedConfig } from '../config/index.ts'
+import type { ResolvedConfig } from '../config/index.ts'
 import type { Plugin } from 'rolldown'
 
 export const shimFile: string = path.resolve(
@@ -8,7 +8,12 @@ export const shimFile: string = path.resolve(
   'esm-shims.js',
 )
 
-export const shimsDefine = {
+const shimsInject: Record<string, [string, string]> = {
+  __dirname: [shimFile, '__dirname'],
+  __filename: [shimFile, '__filename'],
+}
+
+const shimsDefine: Record<string, string> = {
   __dirname: '__TSDOWN_SHIM_DIRNAME__',
   __filename: '__TSDOWN_SHIM_FILENAME__',
 }
@@ -26,14 +31,19 @@ export const shimsPlugin: Plugin = {
   banner: shimsInjectCode,
 }
 
-export function getShimsInject(
-  format: NormalizedFormat,
-  platform: ResolvedConfig['platform'],
-): Record<string, [string, string]> | undefined {
-  if (format === 'es' && platform === 'node') {
+export function getShims(config: ResolvedConfig): {
+  define?: Record<string, string>
+  inject?: Record<string, [string, string]>
+  plugin?: Plugin
+} {
+  if (config.format !== 'es' || config.platform !== 'node') return {}
+
+  if (config.unbundle) {
     return {
-      __dirname: [shimFile, '__dirname'],
-      __filename: [shimFile, '__filename'],
+      define: shimsDefine,
+      plugin: shimsPlugin,
     }
   }
+
+  return { inject: shimsInject }
 }

--- a/tests/__snapshots__/shims/cjs-on-node-with-unbundle.snap.md
+++ b/tests/__snapshots__/shims/cjs-on-node-with-unbundle.snap.md
@@ -1,0 +1,16 @@
+## index.cjs
+
+```cjs
+//#region index.ts
+var cjs_on_node_with_unbundle_default = [
+	__dirname,
+	__filename,
+	require("url").pathToFileURL(__filename).href,
+	__filename,
+	__dirname,
+	{}.something
+];
+//#endregion
+module.exports = cjs_on_node_with_unbundle_default;
+
+```

--- a/tests/__snapshots__/shims/esm-on-node-with-unbundle.snap.md
+++ b/tests/__snapshots__/shims/esm-on-node-with-unbundle.snap.md
@@ -1,0 +1,19 @@
+## index.mjs
+
+```mjs
+import __tsdown_shims_path from "node:path";
+import __tsdown_shims_url from "node:url";
+const __TSDOWN_SHIM_FILENAME__ = /* @__PURE__ */ __tsdown_shims_url.fileURLToPath(import.meta.url);
+//#region index.ts
+var esm_on_node_with_unbundle_default = [
+	/* @__PURE__ */ __tsdown_shims_path.dirname(__TSDOWN_SHIM_FILENAME__),
+	__TSDOWN_SHIM_FILENAME__,
+	import.meta.url,
+	import.meta.filename,
+	import.meta.dirname,
+	import.meta.something
+];
+//#endregion
+export { esm_on_node_with_unbundle_default as default };
+
+```

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -39,6 +39,36 @@ describe('shims', () => {
     ])
   })
 
+  test('esm on node with unbundle', async (context) => {
+    const { snapshot } = await testBuild({
+      context,
+      files: { 'index.ts': code },
+      options: {
+        platform: 'node',
+        shims: true,
+        unbundle: true,
+      },
+    })
+    expect(snapshot).not.contain('__dirname')
+    expect(snapshot).not.contain('__filename')
+    expect(snapshot).contain('fileURLToPath')
+  })
+
+  test('cjs on node with unbundle', async (context) => {
+    const { snapshot } = await testBuild({
+      context,
+      files: { 'index.ts': code },
+      options: {
+        format: 'cjs',
+        platform: 'node',
+        shims: true,
+        unbundle: true,
+      },
+    })
+    expect(snapshot).not.contain('import.meta')
+    expect(snapshot).contain('require("url").pathToFileURL(__filename).href')
+  })
+
   test('cjs on neutral w/o shims', async (context) => {
     const { snapshot } = await testBuild({
       context,


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

With `shims` and `unbundle` on and `cjs` in the format list, the emitted `.cjs` gets the ESM shim banner (`import ... from 'node:path'`, `import.meta.url`), so it isn't valid CommonJS. The build succeeds and ESM works, so nothing tells you it's broken until someone using your lib calls `require()` and gets `SyntaxError: Cannot use import statement outside a module`. This currently breaks the published CJS build of [envapt](https://github.com/materwelonDhruv/envapt).

Bundle mode already avoids this. `getShimsInject` injects only for `format === 'es' && platform === 'node'`, while the unbundle path pushes `shimsPlugin` with no such check. I used that same kind of check. CJS has native `__dirname` and `__filename`, and rolldown already lowers `import.meta.url` to `require("url").pathToFileURL(...)` for CJS, so it doesn't need that top stuff.

The existing shims tests only cover ESM output so this didn't get checked. I added a cjs-unbundle case so the broken output can't come back, and an esm-unbundle case so the guard doesn't drop the top few lines added for ESM.

### Linked Issues

Closes #990 

### Additional context

Nothing.
