### PR TITLE
fix(pkg): await readFile before removing temp pack directory

### DIFF
--- a/src/features/pkg/index.ts
+++ b/src/features/pkg/index.ts
@@ -134,7 +134,7 @@ async function packTarball(
     const tarballPath = await pack(pkgDir, detected, destination, true)
     debug('Packed tarball at %s', tarballPath)
 
-    return readFile(tarballPath)
+    return await readFile(tarballPath)
   } finally {
     if (debug.enabled) {
       debug('Preserving pack directory for debugging: %s', destination)


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Fixes an intermittent `Pack failed: ENOENT ... .tgz` race when `publint` and/or `attw` trigger `packTarball`.

`packTarball` returned `readFile(tarballPath)` without awaiting it inside the `try`. That allowed the `finally` block to remove the temporary pack directory before Bun had opened the tarball for reading, intermittently unlinking the file first.

Awaiting the `readFile` keeps the read operation inside the `try`, so cleanup only runs after the tarball has been fully read into memory.

Verification performed locally:

- Reproduced the issue's Bun race repro with the buggy pattern: `2682/9600` `ENOENT` failures.
- Verified the awaited pattern with the same repro: `0/9600` `ENOENT` failures.
- `pnpm run typecheck`
- `pnpm exec eslint --max-warnings 0 src/features/pkg/index.ts`

### Linked Issues

Fixes #986

### Additional context

No regression test was added because the faithful reproduction is timing-dependent and would be flaky in CI; this PR keeps the fix to the minimal ordering correction described in the issue.