### PR TITLE
perf(css): reuse Sass async compiler

### DIFF
--- a/packages/css/src/plugin.ts
+++ b/packages/css/src/plugin.ts
@@ -14,6 +14,7 @@ import { CssPostPlugin, type CssStyles } from './post.ts'
 import { processWithPostCSS as runPostCSS } from './postcss.ts'
 import {
   compilePreprocessor,
+  disposeSassCompiler,
   getPreprocessorLangFromId,
 } from './preprocessors.ts'
 import {
@@ -74,6 +75,16 @@ export function CssPlugin(
     buildStart() {
       styles.clear()
       modulesMap.clear()
+    },
+
+    closeBundle() {
+      if (!this.meta.watchMode) {
+        return disposeSassCompiler()
+      }
+    },
+
+    closeWatcher() {
+      return disposeSassCompiler()
     },
 
     resolveId: {

--- a/packages/css/src/preprocessors.test.ts
+++ b/packages/css/src/preprocessors.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  disposeSassCompiler,
+  loadSassCompiler,
+  type SassCompiler,
+  type SassModule,
+} from './preprocessors.ts'
+
+function createCompileResult(): { css: string; loadedUrls: URL[] } {
+  return { css: '', loadedUrls: [] }
+}
+
+describe('loadSassCompiler', () => {
+  afterEach(async () => {
+    await disposeSassCompiler()
+  })
+
+  test('reuses async compiler when supported', async () => {
+    const compiler: SassCompiler = {
+      compileStringAsync: vi.fn(() => Promise.resolve(createCompileResult())),
+      dispose: vi.fn(),
+    }
+    const sass: SassModule = {
+      compileStringAsync: vi.fn(() => Promise.resolve(createCompileResult())),
+      initAsyncCompiler: vi.fn(() => Promise.resolve(compiler)),
+    }
+
+    const [firstCompiler, secondCompiler] = await Promise.all([
+      loadSassCompiler(sass),
+      loadSassCompiler(sass),
+    ])
+
+    expect(firstCompiler).toBe(compiler)
+    expect(secondCompiler).toBe(compiler)
+    expect(sass.initAsyncCompiler).toHaveBeenCalledOnce()
+
+    await disposeSassCompiler()
+
+    expect(compiler.dispose).toHaveBeenCalledOnce()
+  })
+
+  test('falls back to module compiler when async compiler is unavailable', async () => {
+    const sass: SassModule = {
+      compileStringAsync: vi.fn(() => Promise.resolve(createCompileResult())),
+    }
+
+    await expect(loadSassCompiler(sass)).resolves.toBe(sass)
+  })
+})

--- a/packages/css/src/preprocessors.ts
+++ b/packages/css/src/preprocessors.ts
@@ -20,6 +20,21 @@ export interface PreprocessResult {
   deps: string[]
 }
 
+export interface SassStringCompiler {
+  compileStringAsync: (
+    source: string,
+    options: Record<string, any>,
+  ) => Promise<{ css: string; loadedUrls: URL[] }>
+}
+
+export interface SassCompiler extends SassStringCompiler {
+  dispose?: () => void | Promise<void>
+}
+
+export interface SassModule extends SassStringCompiler {
+  initAsyncCompiler?: () => Promise<SassCompiler>
+}
+
 export function getPreprocessorLang(
   filename: string,
 ): PreprocessorLang | undefined {
@@ -297,7 +312,8 @@ async function compileSass(
     },
   }
 
-  const result = await sass.compileStringAsync(data, {
+  const compiler = await loadSassCompiler(sass)
+  const result = await compiler.compileStringAsync(data, {
     url: pathToFileURL(filename),
     sourceMap: false,
     syntax: lang === 'sass' ? 'indented' : 'scss',
@@ -355,8 +371,29 @@ async function tryResolveScss(
   return resolveWithResolver(getSassResolver(), url, importer)
 }
 
-let _sass: any
-async function loadSass() {
+let _sass: SassModule | undefined
+let _sassCompiler: Promise<SassCompiler> | undefined
+
+export function loadSassCompiler(
+  sass: SassModule,
+): Promise<SassStringCompiler> {
+  if (!sass.initAsyncCompiler) return Promise.resolve(sass)
+
+  _sassCompiler ??= sass.initAsyncCompiler().catch((error: unknown) => {
+    _sassCompiler = undefined
+    throw error
+  })
+  return _sassCompiler
+}
+
+export async function disposeSassCompiler(): Promise<void> {
+  const compilerPromise = _sassCompiler
+  _sassCompiler = undefined
+  const compiler = await compilerPromise?.catch(() => undefined)
+  await compiler?.dispose?.()
+}
+
+async function loadSass(): Promise<SassModule> {
   if (_sass) return _sass
   try {
     // @ts-ignore -- optional peer dependency


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Fixes #1000.

`@tsdown/css` now reuses a Sass `AsyncCompiler` when the loaded Sass implementation exposes `initAsyncCompiler()`. This avoids module-level `compileStringAsync()` spawning an embedded compiler for each SCSS transform. The compiler is disposed after non-watch builds and when the watcher closes, so watch rebuilds can keep reusing it between runs.

This also adds focused tests for async compiler reuse and fallback to module-level Sass compilation.

### Linked Issues

Fixes #1000

### Additional context

Validated with:

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test run`