### PR TITLE
fix(create-tsdown): skip cd hint for current directory

### DIFF
--- a/packages/create-tsdown/src/index.ts
+++ b/packages/create-tsdown/src/index.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
 import {
@@ -53,9 +54,12 @@ export async function create(
   s.stop('Template cloned')
 
   const pm = getUserAgent() || 'npm'
+  const cdCommand =
+    resolve(resolved.path) === process.cwd()
+      ? ''
+      : `  ${styleText('green', `cd ${resolved.path}`)}\n`
   outro(
-    `Done! Now run:\n` +
-      `  ${styleText('green', `cd ${resolved.path}`)}\n` +
+    `Done! Now run:\n${cdCommand}` +
       `  ${styleText('green', `${pm} install`)}\n` +
       `  ${styleText('green', `${pm} run build`)}\n\n` +
       `For more information, visit: ${styleText('underline', `https://tsdown.dev/`)}`,


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

- Skip the redundant `cd .` instruction when `create-tsdown` creates a project in the current directory.

### Linked Issues

Closes #989 

### Additional context

Nothing
