### PR TITLE
fix(deps): externalize unresolvable bare deps with skipNodeModulesBundle

### DIFF
--- a/src/features/deps.ts
+++ b/src/features/deps.ts
@@ -331,16 +331,23 @@ export function DepsPlugin(
       return 'no-external'
     }
 
-    if (skipNodeModulesBundle) {
-      if (resolved) {
-        if (resolved.external || RE_NODE_MODULES.test(resolved.id)) {
-          const resolvedDep = await resolveDepSubpath(id, resolved)
-          return resolvedDep ? [true, resolvedDep] : true
-        }
-      } else if (!path.isAbsolute(id) && !id.startsWith('#')) {
-        // externalize even when unresolvable (e.g. no `exports` field on a non-`node` platform)
-        return true
-      }
+    if (
+      skipNodeModulesBundle &&
+      resolved &&
+      (resolved.external || RE_NODE_MODULES.test(resolved.id))
+    ) {
+      const resolvedDep = await resolveDepSubpath(id, resolved)
+      return resolvedDep ? [true, resolvedDep] : true
+    }
+
+    // externalize even when unresolvable (e.g. no `exports` field on a non-`node` platform)
+    if (
+      skipNodeModulesBundle &&
+      !resolved &&
+      !path.isAbsolute(id) &&
+      !id.startsWith('#')
+    ) {
+      return true
     }
 
     if (deps) {

--- a/src/features/deps.ts
+++ b/src/features/deps.ts
@@ -331,13 +331,16 @@ export function DepsPlugin(
       return 'no-external'
     }
 
-    if (
-      skipNodeModulesBundle &&
-      resolved &&
-      (resolved.external || RE_NODE_MODULES.test(resolved.id))
-    ) {
-      const resolvedDep = await resolveDepSubpath(id, resolved)
-      return resolvedDep ? [true, resolvedDep] : true
+    if (skipNodeModulesBundle) {
+      if (resolved) {
+        if (resolved.external || RE_NODE_MODULES.test(resolved.id)) {
+          const resolvedDep = await resolveDepSubpath(id, resolved)
+          return resolvedDep ? [true, resolvedDep] : true
+        }
+      } else if (!path.isAbsolute(id) && !id.startsWith('#')) {
+        // externalize even when unresolvable (e.g. no `exports` field on a non-`node` platform)
+        return true
+      }
     }
 
     if (deps) {

--- a/tests/__snapshots__/resolve-dep-subpath-without-exports-field/skipNodeModulesBundle-externalizes-an-unresolvable-dep-on-a-non-node-platform.snap.md
+++ b/tests/__snapshots__/resolve-dep-subpath-without-exports-field/skipNodeModulesBundle-externalizes-an-unresolvable-dep-on-a-non-node-platform.snap.md
@@ -1,0 +1,12 @@
+## index.d.mts
+
+```mts
+import { Foo } from "my-dep";
+export type { Foo };
+```
+
+## index.mjs
+
+```mjs
+
+```

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1180,6 +1180,38 @@ describe('resolve dep subpath without exports field', () => {
 
     expect(fileMap['index.mjs']).toContain('my-dep/folder/index.js')
   })
+
+  test('skipNodeModulesBundle externalizes an unresolvable dep on a non-node platform', async (context) => {
+    const node_modules = {
+      // A types-only dependency (no `main`/`exports`, no JS entry).
+      'node_modules/my-dep/package.json': JSON.stringify({
+        name: 'my-dep',
+        version: '1.0.0',
+        types: 'index.d.ts',
+      }),
+      'node_modules/my-dep/index.d.ts': `export interface Foo { a: number }`,
+    }
+
+    const { fileMap } = await testBuild({
+      context,
+      files: {
+        ...node_modules,
+        'index.ts': `export type { Foo } from 'my-dep'`,
+        'package.json': JSON.stringify({
+          name: 'test-pkg',
+          version: '1.0.0',
+        }),
+      },
+      options: {
+        platform: 'neutral',
+        dts: true,
+        deps: { skipNodeModulesBundle: true },
+      },
+    })
+
+    expect(fileMap['index.d.mts']).toContain('from "my-dep"')
+    expect(fileMap['index.d.mts']).not.toContain('interface Foo')
+  })
 })
 
 test('.node file bundle', async (context) => {


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

`deps.skipNodeModulesBundle: true` is documented as "Skip bundling all `node_modules` dependencies", but a bare dependency the resolver can't resolve is bundled instead of externalized.

This happens for a dependency published without an `exports` field on a non-`node` platform: the resolver doesn't fall back to the legacy `main`/`types` fields, so `this.resolve(...)` returns `null`. In `externalStrategy` (`src/features/deps.ts`) the `skipNodeModulesBundle` branch was gated on `resolved` being truthy, so a `null` resolution fell through to `return false` and the bare import got bundled.

It's most visible in the dts build, where a types-only dependency ends up inlined into the emitted `.d.ts` instead of being kept as an external import:

**Before**
```mts
//#region node_modules/my-dep/index.d.ts
interface Foo { a: number; }
//#endregion
export type { Foo };
```

**After**
```mts
import { Foo } from "my-dep";
export type { Foo };
```

The fix externalizes the bare specifier in this case too — `skipNodeModulesBundle` should never bundle a `node_modules` import whether or not it resolves. Absolute paths and `#` subpath imports are left untouched, and the change is fully scoped to `skipNodeModulesBundle`, so default resolution and the existing "Module not found" path (without this option) are unaffected.

Added a regression test in `tests/e2e.test.ts` (types-only dep + `dts: true` + `platform: 'neutral'` + `skipNodeModulesBundle: true`) that fails without the change and passes with it. `pnpm test` (full suite), `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` all pass.

### Linked Issues

fixes #993

### Additional context

The bug reproduces only with the combination in the test: a non-`node` platform + a dependency lacking an `exports` field (so the resolver returns `null`). On a `node` platform the same dependency resolves via `main`, so `skipNodeModulesBundle` already externalizes it correctly.


With the option on, an unresolvable bare import is externalized rather than raising an unresolved-module error — the behavior #993 asks for ("regardless of whether the resolver can resolve it").

