### PR TITLE
fix: evaluate banner/footer function addon per chunk

### DIFF
--- a/src/features/output.ts
+++ b/src/features/output.ts
@@ -107,24 +107,25 @@ export function resolveChunkAddon(
   if (!chunkAddon) return
 
   return (chunk: RenderedChunk) => {
-    if (typeof chunkAddon === 'function') {
-      chunkAddon = chunkAddon({
-        format,
-        fileName: chunk.fileName,
-      })
-    }
+    const resolved =
+      typeof chunkAddon === 'function'
+        ? chunkAddon({
+            format,
+            fileName: chunk.fileName,
+          })
+        : chunkAddon
 
-    if (typeof chunkAddon === 'string') {
-      return chunkAddon
+    if (typeof resolved === 'string') {
+      return resolved
     }
 
     switch (true) {
       case RE_JS.test(chunk.fileName):
-        return chunkAddon?.js || ''
+        return resolved?.js || ''
       case RE_CSS.test(chunk.fileName):
-        return chunkAddon?.css || ''
+        return resolved?.css || ''
       case RE_DTS.test(chunk.fileName):
-        return chunkAddon?.dts || ''
+        return resolved?.dts || ''
       default:
         return ''
     }

--- a/tests/__snapshots__/banner-and-footer-function-run-per-chunk.snap.md
+++ b/tests/__snapshots__/banner-and-footer-function-run-per-chunk.snap.md
@@ -1,0 +1,23 @@
+## a.mjs
+
+```mjs
+// banner:a.mjs
+//#region a.ts
+const a = 1;
+//#endregion
+export { a };
+
+// footer:a.mjs
+```
+
+## b.mjs
+
+```mjs
+// banner:b.mjs
+//#region b.ts
+const b = 2;
+//#endregion
+export { b };
+
+// footer:b.mjs
+```

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -805,6 +805,26 @@ test('banner and footer option', async (context) => {
   expect(fileMap['index.d.mts']).toContain('// dts footer')
 })
 
+test('banner and footer function run per chunk', async (context) => {
+  const { fileMap } = await testBuild({
+    context,
+    files: {
+      'a.ts': `export const a = 1`,
+      'b.ts': `export const b = 2`,
+    },
+    options: {
+      entry: ['a.ts', 'b.ts'],
+      banner: ({ fileName }) => `// banner:${fileName}`,
+      footer: ({ fileName }) => `// footer:${fileName}`,
+    },
+  })
+
+  expect(fileMap['a.mjs']).toContain('// banner:a.mjs')
+  expect(fileMap['a.mjs']).toContain('// footer:a.mjs')
+  expect(fileMap['b.mjs']).toContain('// banner:b.mjs')
+  expect(fileMap['b.mjs']).toContain('// footer:b.mjs')
+})
+
 test('dts enabled when exports.types exists', async (context) => {
   const files = {
     'index.ts': `export const hello = "world"`,


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

`resolveChunkAddon` returns an `AddonFunction` that Rolldown calls once per output chunk. When `banner`/`footer` is a function, the closure reassigned its own `chunkAddon` parameter with the first chunk's result:

```ts
if (typeof chunkAddon === 'function') {
  chunkAddon = chunkAddon({ format, fileName: chunk.fileName })
}
```

After the first chunk `chunkAddon` is no longer a function, so it is never invoked again — every later chunk reuses the first chunk's value. This was harmless when the context was only `{ format }`, but once `fileName` was added to the context (and string returns were allowed) it means:

- the `fileName` handed to the function is always the first chunk's name, and
- a function returning a string produces the same string for every chunk.

Fix: compute a local `resolved` value on each invocation instead of overwriting the parameter.

### Linked Issues

### Additional context

Added a regression test that builds two entries with `banner`/`footer` functions echoing `fileName`. On `main` the second chunk gets the first chunk's banner/footer; with this fix each chunk gets its own.
