### PR TITLE
docs: note about typescript@7.0.x to options/dts.md

### DIFF
--- a/docs/options/dts.md
+++ b/docs/options/dts.md
@@ -5,7 +5,7 @@ Declaration files (`.d.ts`) are an essential part of TypeScript libraries, provi
 `tsdown` makes it easy to generate and bundle declaration files for your library, ensuring a seamless developer experience for your users.
 
 > [!NOTE]
-> You must install `typescript` in your project for declaration file generation to work properly. Additionally, if you're using typescript@7.0.x, you'll also need to install @typescript/native-preview.
+> You must install `typescript` in your project for declaration file generation to work properly. Additionally, if you're using `typescript@7.0.x`, you'll also need to install `@typescript/native-preview`.
 
 ## How dts Works in tsdown
 

--- a/docs/options/dts.md
+++ b/docs/options/dts.md
@@ -5,7 +5,7 @@ Declaration files (`.d.ts`) are an essential part of TypeScript libraries, provi
 `tsdown` makes it easy to generate and bundle declaration files for your library, ensuring a seamless developer experience for your users.
 
 > [!NOTE]
-> You must install `typescript` in your project for declaration file generation to work properly.
+> You must install `typescript` in your project for declaration file generation to work properly. Additionally, if you're using typescript@7.0.x, you'll also need to install @typescript/native-preview.
 
 ## How dts Works in tsdown
 


### PR DESCRIPTION
document that `typescript@7.0.x` requires `@typescript/native-preview` when use dts generate to options/dts.md .

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

### Description

at moment, if you install only `typescript@7.0.x` package, you will fail d.ts file generating. so you must install also `@typescript/native-preview`. 
this Pull Request document that problem to options/dts.md.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Also, According to microsoft, `typescript^7.1.0` will have api. so this Pull Request touch only `typescript@7.0.x` .
if you think you should change expression, it's welcome. i'm not good of English.