### PR TITLE
docs: update Rolldown links to correct URL structure

### DIFF
--- a/docs/advanced/rolldown-options.md
+++ b/docs/advanced/rolldown-options.md
@@ -2,7 +2,7 @@
 
 `tsdown` uses [Rolldown](https://rolldown.rs) as its core bundling engine. This allows you to easily pass or override options directly to Rolldown, giving you fine-grained control over the bundling process.
 
-For a full list of available Rolldown options, refer to the [Rolldown Config Options](https://rolldown.rs/options/input) documentation.
+For a full list of available Rolldown options, refer to the [Rolldown Config Options](https://rolldown.rs/reference/InputOptions.input) documentation.
 
 > [!WARNING]
 > You should be familiar with the behavior of the Rolldown options you are overriding and ensure you have read the Rolldown documentation.

--- a/docs/options/platform.md
+++ b/docs/options/platform.md
@@ -62,4 +62,4 @@ export default defineConfig({
 })
 ```
 
-See the [Rolldown resolve options documentation](https://rolldown.rs/options/resolve#mainfields) for more details.
+See the [Rolldown resolve options documentation](https://rolldown.rs/reference/InputOptions.resolve#mainfields) for more details.

--- a/docs/zh-CN/advanced/rolldown-options.md
+++ b/docs/zh-CN/advanced/rolldown-options.md
@@ -2,7 +2,7 @@
 
 `tsdown` 使用 [Rolldown](https://rolldown.rs) 作为其核心打包引擎。这使您可以轻松地直接向 Rolldown 传递或覆盖选项，从而对打包过程进行细粒度的控制。
 
-有关可用 Rolldown 选项的完整列表，请参阅 [Rolldown 配置选项](https://rolldown.rs/options/input) 文档。
+有关可用 Rolldown 选项的完整列表，请参阅 [Rolldown 配置选项](https://rolldown.rs/reference/InputOptions.input) 文档。
 
 > [!WARNING]
 > 您应当熟悉您所覆盖的 Rolldown 选项的行为，并确保已阅读 Rolldown 的相关文档。

--- a/docs/zh-CN/options/platform.md
+++ b/docs/zh-CN/options/platform.md
@@ -62,4 +62,4 @@ export default defineConfig({
 })
 ```
 
-更多详情请参阅 [Rolldown 解析选项文档](https://rolldown.rs/options/resolve#mainfields)。
+更多详情请参阅 [Rolldown 解析选项文档](https://rolldown.rs/reference/InputOptions.resolve#mainfields)。

--- a/skills/tsdown/references/advanced-rolldown-options.md
+++ b/skills/tsdown/references/advanced-rolldown-options.md
@@ -6,7 +6,7 @@ Pass options directly to the underlying Rolldown bundler.
 
 tsdown uses [Rolldown](https://rolldown.rs) as its core bundling engine. You can override Rolldown's input and output options directly for fine-grained control.
 
-**Warning:** You should be familiar with Rolldown's behavior before overriding options. Refer to the [Rolldown Config Options](https://rolldown.rs/options/input) documentation.
+**Warning:** You should be familiar with Rolldown's behavior before overriding options. Refer to the [Rolldown Config Options](https://rolldown.rs/reference/InputOptions.input) documentation.
 
 ## Input Options
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -293,7 +293,7 @@ export interface UserConfig {
 
   /**
    * Configure tree shaking options.
-   * @see {@link https://rolldown.rs/options/treeshake} for more details.
+   * @see {@link https://rolldown.rs/reference/InputOptions.treeshake} for more details.
    * @default true
    */
   treeshake?: boolean | TreeshakingOptions


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

Note: Since this project is not one that AI currently excels at, we do not accept Vibe coding or AI-generated core code (documentation excluded) unless it has been thoroughly reviewed line by line by a human. Please do not submit AI-generated pull requests directly, as this increases the workload for maintainers.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Some Rolldown documentation links are returning 404 errors. It appears that the redirection implemented in rolldown/rolldown#7834  is not working as expected. This PR updates the broken links to point to the correct URLs for each documentation page.

   **Changes:**
   - `docs/advanced/rolldown-options.md`
   - `docs/zh-CN/advanced/rolldown-options.md`
   - `docs/zh-CN/options/platform.md`
   - `skills/tsdown/references/advanced-rolldown-options.md`
   - `src/config/types.ts` - JSDoc `@see` URL on `treeshake` option
   