### PR TITLE
ci: migrate Void deploy to GitHub OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
     if: github.repository == 'rolldown/tsdown'
     runs-on: ubuntu-latest
     environment: void
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -50,5 +52,4 @@ jobs:
 
       - run: pnpm -C docs run void deploy
         env:
-          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
           VOID_PROJECT: tsdown

--- a/.github/workflows/src/deploy.yml
+++ b/.github/workflows/src/deploy.yml
@@ -21,10 +21,11 @@ jobs:
     if: github.repository == 'rolldown/tsdown'
     runs-on: ubuntu-latest
     environment: void
+    permissions:
+      id-token: write
     steps:
       - uses: sxzz/workflows/setup-js@main
       - run: pnpm run docs:generate
       - run: pnpm -C docs run void deploy
         env:
-          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
           VOID_PROJECT: tsdown


### PR DESCRIPTION
Authenticate the Void deploy via **GitHub OIDC** instead of a stored `VOID_TOKEN` secret. `void deploy` mints an OIDC token and exchanges it for a short-lived, project-scoped deploy token — no long-lived secret is stored.

## Changes
- Grant `id-token: write` on the `deploy-void` job.
- Drop `VOID_TOKEN` from the deploy step env (`VOID_PROJECT` unchanged).

Applied to both the actionspack source (`.github/workflows/src/deploy.yml`) and the generated `.github/workflows/deploy.yml`. I edited the generated file directly rather than running a full `actionspack` regen, so this doesn't pull unrelated upstream (`sxzz/workflows`) template changes; a future regen reproduces the same change from the source.

## Required follow-up (server-side, one-time)
OIDC only succeeds once the repo is connected to the `tsdown` project with the `github_actions` executor on Void:

```bash
void github connect tsdown \
  --repo rolldown/tsdown \
  --branch main \
  --executor github_actions \
  --workflow .github/workflows/deploy.yml
```

After the first successful OIDC deploy, the `VOID_TOKEN` secret can be removed.