### PR TITLE
docs: explain in-memory programmatic builds

### DIFF
--- a/docs/advanced/programmatic-usage.md
+++ b/docs/advanced/programmatic-usage.md
@@ -16,4 +16,37 @@ await build({
 })
 ```
 
+## In-Memory Output
+
+Set `write: false` to access generated chunks and assets without writing the
+bundle output to disk:
+
+```ts twoslash
+import { build } from 'tsdown'
+
+const bundles = await build({
+  entry: ['src/index.ts'],
+  format: 'esm',
+  write: false,
+  clean: false,
+})
+
+for (const bundle of bundles) {
+  for (const output of bundle.chunks) {
+    const contents = output.type === 'chunk' ? output.code : output.source
+    console.log(output.fileName, contents)
+  }
+}
+```
+
+`build()` currently returns a `TsdownBundle[]`, with one bundle for each
+resolved configuration. Even a single configuration returns an array; its
+in-memory Rolldown outputs are available in `bundle.chunks`.
+
+The `write` option controls Rolldown's bundle output, while other file operations
+are configured separately. For example, `clean` defaults to `true`, so set
+`clean: false` as above if existing output directories must remain untouched.
+Explicitly enabled features such as `copy` or `exports` may still write files.
+`write: false` is incompatible with watch mode.
+
 All CLI options are available as properties in the options object. See [Config Options](../reference/api/Interface.UserConfig.md) for the full list.

--- a/docs/zh-CN/advanced/programmatic-usage.md
+++ b/docs/zh-CN/advanced/programmatic-usage.md
@@ -16,4 +16,30 @@ await build({
 })
 ```
 
+## 内存中的输出
+
+设置 `write: false` 可以访问生成的代码块（chunk）和资源（asset），而不将打包产物写入磁盘：
+
+```ts twoslash
+import { build } from 'tsdown'
+
+const bundles = await build({
+  entry: ['src/index.ts'],
+  format: 'esm',
+  write: false,
+  clean: false,
+})
+
+for (const bundle of bundles) {
+  for (const output of bundle.chunks) {
+    const contents = output.type === 'chunk' ? output.code : output.source
+    console.log(output.fileName, contents)
+  }
+}
+```
+
+`build()` 当前返回 `TsdownBundle[]`，每个解析后的配置对应一个 bundle。即使只有单个配置，返回值也是数组；内存中的 Rolldown 输出位于 `bundle.chunks`。
+
+`write` 选项控制 Rolldown 打包产物的写入，其他文件操作则单独配置。例如，`clean` 默认为 `true`，因此如果必须保留现有输出目录，请像上面的示例一样设置 `clean: false`。显式启用的 `copy` 或 `exports` 等功能仍可能写入文件。`write: false` 与监听模式不兼容。
+
 所有 CLI 选项都可以作为参数对象的属性传递。完整选项请参见 [配置选项](../reference/api/Interface.UserConfig.md)。

--- a/skills/tsdown/references/advanced-programmatic.md
+++ b/skills/tsdown/references/advanced-programmatic.md
@@ -36,6 +36,39 @@ await build({
 })
 ```
 
+### In-Memory Output
+
+Set `write: false` to access generated chunks and assets without writing the
+bundle output to disk:
+
+```ts
+import { build } from 'tsdown'
+
+const bundles = await build({
+  entry: ['src/index.ts'],
+  format: 'esm',
+  write: false,
+  clean: false,
+})
+
+for (const bundle of bundles) {
+  for (const output of bundle.chunks) {
+    const contents = output.type === 'chunk' ? output.code : output.source
+    console.log(output.fileName, contents)
+  }
+}
+```
+
+`build()` currently returns a `TsdownBundle[]`, with one bundle for each
+resolved configuration. Even a single configuration returns an array; its
+in-memory Rolldown outputs are available in `bundle.chunks`.
+
+The `write` option controls Rolldown's bundle output, while other file operations
+are configured separately. For example, `clean` defaults to `true`, so set
+`clean: false` as above if existing output directories must remain untouched.
+Explicitly enabled features such as `copy` or `exports` may still write files.
+`write: false` is incompatible with watch mode.
+
 ## API Reference
 
 ### build()
@@ -52,7 +85,7 @@ await build(options)
 - `options` - Build configuration object (same as config file)
 
 **Returns:**
-- `Promise<void>` - Resolves when build completes
+- `Promise<TsdownBundle[]>` - One bundle for each resolved configuration
 
 **Throws:**
 - Build errors if compilation fails


### PR DESCRIPTION
- [x] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Documents the Programmatic Usage write:false item from #247 across the English guide, Chinese guide, and synchronized tsdown skill reference.

The new section shows an in-memory build, explains chunk and asset content access, documents the current TsdownBundle[] return shape, notes remaining filesystem side effects, and calls out the watch-mode incompatibility. It also corrects the skill reference’s stale Promise<void> description.

This is AI-assisted documentation, not core code. The final diff was validated against the implementation with a live runtime probe and independently reviewed.

Validation:
- live build({ write:false, clean:false }) probe returned an in-memory bundle
- pnpm lint
- pnpm typecheck
- pnpm docs:generate
- pnpm docs:build
- targeted Prettier and git diff --check

### Linked Issues

Addresses the unchecked Programmatic Usage write:false documentation item in #247.

### Additional context

The docs explicitly avoid combining write:false with watch mode because current watch rebuilds do not expose returned bundles.