### PR TITLE
docs: document copy option

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -124,6 +124,7 @@ export function getLocaleConfig(lang: string) {
         { text: t('Output Format'), link: '/output-format.md' },
         { text: t('Output Directory'), link: '/output-directory.md' },
         { text: t('Cleaning'), link: '/cleaning.md' },
+        { text: t('Copy Files'), link: '/copy.md' },
         { text: t('Dependencies'), link: '/dependencies.md' },
         { text: t('Watch Mode'), link: '/watch-mode.md' },
         { text: t('Target'), link: '/target.md' },

--- a/docs/.vitepress/i18n/translate-map.ts
+++ b/docs/.vitepress/i18n/translate-map.ts
@@ -15,6 +15,7 @@ const zhCN = {
   Options: '选项',
   Entry: '入口文件',
   Cleaning: '清理',
+  'Copy Files': '复制文件',
   Dependencies: '依赖',
   'Config File': '配置文件',
   Minification: '压缩',

--- a/docs/options/copy.md
+++ b/docs/options/copy.md
@@ -1,0 +1,138 @@
+# Copy Files
+
+The `copy` option copies static files and directories into your build output. It
+is useful for assets that should be distributed without being processed by the
+bundler, such as images, fonts, and license files.
+
+## Using the CLI
+
+Pass a directory to `--copy` to copy it into the output directory:
+
+```bash
+tsdown --copy public
+```
+
+With the default `outDir` of `dist`, a file at `public/favicon.svg` is copied to
+`dist/public/favicon.svg`.
+
+## Using the Config File
+
+The simplest configuration is a path or glob pattern:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: 'public',
+})
+```
+
+You can provide multiple paths, glob patterns, or object entries in an array:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: [
+    'LICENSE',
+    {
+      from: ['public/**/*', '!public/**/*.map'],
+      to: 'dist/assets',
+      flatten: false,
+    },
+  ],
+})
+```
+
+Glob patterns support negation with a leading `!`. In this example, files below
+`public` are copied to `dist/assets` with their relative directory structure
+preserved, while source map files are excluded.
+
+> [!NOTE]
+> Relative source and destination paths are resolved from the project root
+> (`cwd`), not from `outDir`.
+
+## Object Options
+
+Object entries support the following properties:
+
+| Property  | Type                                                | Default  | Description                                                                                                        |
+| --------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `from`    | `string \| string[]`                                | Required | A source path or glob pattern. An array can include negated patterns.                                              |
+| `to`      | `string`                                            | `outDir` | The destination path, resolved from the project root.                                                              |
+| `flatten` | `boolean`                                           | `true`   | Places matched files directly in `to`. Set to `false` to preserve the directory structure below the first segment. |
+| `rename`  | `string \| ((name, extension, fullPath) => string)` | —        | Changes the destination name. The callback receives the extension without a leading dot and the absolute path.     |
+| `verbose` | `boolean`                                           | `false`  | Logs each copied source and destination.                                                                           |
+
+### Preserve Directory Structure
+
+Glob matches are flattened into the destination by default. Set
+`flatten: false` to keep their relative structure:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: {
+    from: 'assets/**/*',
+    to: 'dist/public',
+    flatten: false,
+  },
+})
+```
+
+For example, `assets/fonts/inter.woff2` is copied to
+`dist/public/fonts/inter.woff2`.
+
+### Rename Copied Items
+
+Use a string or a callback to rename copied items:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: [
+    {
+      from: 'src/file.txt',
+      to: 'dist',
+      rename: 'file.md',
+    },
+    {
+      from: 'src/file.txt',
+      to: 'dist',
+      rename: (name, extension) => `${name}-renamed.${extension}`,
+    },
+  ],
+})
+```
+
+This creates `dist/file.md` and `dist/file-renamed.txt`.
+
+## Dynamic Configuration
+
+`copy` can also be a synchronous or asynchronous callback. It receives the
+resolved tsdown configuration and returns the same string, object, or array
+forms:
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: ({ outDir }) => ({
+    from: ['assets/**/*', '!assets/**/*.map'],
+    to: `${outDir}/assets`,
+    flatten: false,
+  }),
+})
+```
+
+## Build and Watch Behavior
+
+Copying runs after the bundle output is produced. Static files are copied
+without passing through Rolldown transforms. A top-level `copy` option runs only
+once for a multi-format build; a format-specific override can define `copy`
+again for that format.
+
+In watch mode, matched source files are watched as build dependencies. Changing
+one triggers a rebuild and copies the current files again.

--- a/docs/zh-CN/options/copy.md
+++ b/docs/zh-CN/options/copy.md
@@ -1,0 +1,124 @@
+# 复制文件
+
+`copy` 选项用于将静态文件和目录复制到构建输出中。它适合处理不需要经过打包器转换、但需要随包一起发布的资源，例如图片、字体和许可证文件。
+
+## 使用 CLI
+
+将目录传给 `--copy`，即可把它复制到输出目录：
+
+```bash
+tsdown --copy public
+```
+
+当 `outDir` 使用默认值 `dist` 时，`public/favicon.svg` 会被复制到 `dist/public/favicon.svg`。
+
+## 使用配置文件
+
+最简单的配置是一个路径或 glob 模式：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: 'public',
+})
+```
+
+您可以在数组中指定多个路径、glob 模式或对象配置：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: [
+    'LICENSE',
+    {
+      from: ['public/**/*', '!public/**/*.map'],
+      to: 'dist/assets',
+      flatten: false,
+    },
+  ],
+})
+```
+
+glob 模式支持使用 `!` 前缀进行排除。在此示例中，`public` 下的文件会复制到 `dist/assets` 并保留相对目录结构，同时排除源映射文件。
+
+> [!NOTE]
+> 相对的源路径和目标路径都基于项目根目录（`cwd`）解析，而不是基于 `outDir`。
+
+## 对象选项
+
+对象配置支持以下属性：
+
+| 属性      | 类型                                                | 默认值   | 说明                                                                           |
+| --------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------ |
+| `from`    | `string \| string[]`                                | 必填     | 源路径或 glob 模式。数组中可以包含否定模式。                                   |
+| `to`      | `string`                                            | `outDir` | 目标路径，基于项目根目录解析。                                                 |
+| `flatten` | `boolean`                                           | `true`   | 将匹配的文件直接放入 `to`。设为 `false` 时，会保留第一个路径段之后的目录结构。 |
+| `rename`  | `string \| ((name, extension, fullPath) => string)` | —        | 修改目标名称。回调接收不带前导点的扩展名和绝对路径。                           |
+| `verbose` | `boolean`                                           | `false`  | 记录每个复制操作的源路径和目标路径。                                           |
+
+### 保留目录结构
+
+默认情况下，glob 匹配到的文件会被直接放入目标目录。设置 `flatten: false` 可以保留其相对目录结构：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: {
+    from: 'assets/**/*',
+    to: 'dist/public',
+    flatten: false,
+  },
+})
+```
+
+例如，`assets/fonts/inter.woff2` 会被复制到 `dist/public/fonts/inter.woff2`。
+
+### 重命名复制项
+
+使用字符串或回调可以重命名复制项：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: [
+    {
+      from: 'src/file.txt',
+      to: 'dist',
+      rename: 'file.md',
+    },
+    {
+      from: 'src/file.txt',
+      to: 'dist',
+      rename: (name, extension) => `${name}-renamed.${extension}`,
+    },
+  ],
+})
+```
+
+此配置会生成 `dist/file.md` 和 `dist/file-renamed.txt`。
+
+## 动态配置
+
+`copy` 也可以是同步或异步回调。回调接收解析后的 tsdown 配置，并返回相同的字符串、对象或数组形式：
+
+```ts [tsdown.config.ts]
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  copy: ({ outDir }) => ({
+    from: ['assets/**/*', '!assets/**/*.map'],
+    to: `${outDir}/assets`,
+    flatten: false,
+  }),
+})
+```
+
+## 构建和监听行为
+
+复制操作会在打包输出生成后运行，静态文件不会经过 Rolldown 转换。对于多格式构建，顶层 `copy` 选项只运行一次；特定格式的覆盖配置可以为该格式再次定义 `copy`。
+
+在监听模式下，匹配到的源文件会被作为构建依赖进行监听。文件发生变化时会触发重新构建，并再次复制当前文件。


### PR DESCRIPTION
### Description

Add dedicated English and Chinese documentation for the `copy` option,
including:

- CLI and config-file usage
- paths, globs, and negated patterns
- `from`, `to`, `flatten`, `rename`, and `verbose`
- synchronous and asynchronous config callbacks
- build, multi-format, and watch behavior

The pages are added to the localized Options sidebar.

### Linked Issues

Implements the unchecked `copy` documentation item in #247.

### Validation

- `pnpm docs:build`
- `pnpm lint`
- `pnpm test src/features/copy.test.ts --run` (6 passed)
- Prettier check
- `git diff --check origin/main...HEAD`
- rendered-route and localized-sidebar probes

`pnpm -C docs run typecheck` reports the same five pre-existing errors on this
branch and a clean `origin/main` worktree (one `VideoModal.vue` mismatch and
four unresolved virtual/style imports).

### Additional context

Assisted by OpenAI Codex. The documentation was checked against the current
`copy` implementation, configuration resolution, watch plugin, CLI reference,
and unit tests. An independent agent review also checked behavioral accuracy
and prompted a clarification of top-level versus format-specific copy behavior.
