### PR TITLE
feat(css): support function form for `css.modules.localsConvention`

### DIFF
--- a/docs/options/css.md
+++ b/docs/options/css.md
@@ -386,6 +386,21 @@ Controls how class names are exported in JavaScript:
 | `'dashes'`        | `foo-bar` | `foo-bar`, `fooBar` |
 | `'dashesOnly'`    | `foo-bar` | `fooBar`            |
 
+A function can also be passed to derive the exported name from each class name:
+
+```ts
+export default defineConfig({
+  css: {
+    modules: {
+      localsConvention: (originalClassName, generatedClassName, inputFile) =>
+        originalClassName.replaceAll(/-([a-z0-9])/g, (_, char) =>
+          char.toUpperCase(),
+        ),
+    },
+  },
+})
+```
+
 ### `generateScopedName`
 
 When using `transformer: 'lightningcss'` (default), this accepts a Lightning CSS [pattern string](https://lightningcss.dev/css-modules.html#custom-naming-conventions) (e.g., `'[hash]_[local]'`).

--- a/packages/css/src/modules.test.ts
+++ b/packages/css/src/modules.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { modulesToEsm } from './modules.ts'
+import { applyLocalsConvention, modulesToEsm } from './modules.ts'
 
 describe('modulesToEsm', () => {
   test('exports arbitrary module keys via aliased bindings', () => {
@@ -22,5 +22,38 @@ describe('modulesToEsm', () => {
     expect(code).toContain(
       'export default {"default":"mod_default","title":"mod_title","await":"mod_await","foo-bar":"mod_foo_bar"};',
     )
+  })
+})
+
+describe('applyLocalsConvention', () => {
+  test('camelCaseOnly exports only the camelized key', () => {
+    const result = applyLocalsConvention(
+      { 'foo-bar': 'a', baz: 'b' },
+      'camelCaseOnly',
+      'style.module.css',
+    )
+    expect(result).toEqual({ fooBar: 'a', baz: 'b' })
+  })
+
+  test('function convention maps each key through the callback', () => {
+    const result = applyLocalsConvention(
+      { 'foo-bar': 'a', baz: 'b' },
+      (name) => name.toUpperCase(),
+      'style.module.css',
+    )
+    expect(result).toEqual({ 'FOO-BAR': 'a', BAZ: 'b' })
+  })
+
+  test('function convention receives class name, scoped name, and filename', () => {
+    const calls: Array<[string, string, string]> = []
+    applyLocalsConvention(
+      { 'foo-bar': 'scoped_foo_bar' },
+      (original, generated, file) => {
+        calls.push([original, generated, file])
+        return original
+      },
+      'style.module.css',
+    )
+    expect(calls).toEqual([['foo-bar', 'scoped_foo_bar', 'style.module.css']])
   })
 })

--- a/packages/css/src/modules.ts
+++ b/packages/css/src/modules.ts
@@ -1,3 +1,4 @@
+import type { CSSModulesLocalsConvention } from './options.ts'
 import type { CSSModuleExports } from 'lightningcss'
 
 export function modulesToEsm(modules: Record<string, string>): string {
@@ -23,10 +24,15 @@ function dashToCamel(str: string): string {
 
 export function applyLocalsConvention(
   modules: Record<string, string>,
-  convention: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly',
+  convention: CSSModulesLocalsConvention,
+  filename: string,
 ): Record<string, string> {
   const result: Record<string, string> = {}
   for (const [key, value] of Object.entries(modules)) {
+    if (typeof convention === 'function') {
+      result[convention(key, value, filename)] = value
+      continue
+    }
     const camelized = dashToCamel(key)
     switch (convention) {
       case 'camelCase':

--- a/packages/css/src/options.ts
+++ b/packages/css/src/options.ts
@@ -12,6 +12,17 @@ export type LightningCSSOptions = Omit<
   'filename' | 'code'
 >
 
+export type CSSModulesLocalsConvention =
+  | 'camelCase'
+  | 'camelCaseOnly'
+  | 'dashes'
+  | 'dashesOnly'
+  | ((
+      originalClassName: string,
+      generatedClassName: string,
+      inputFile: string,
+    ) => string)
+
 export interface CSSModulesOptions {
   /**
    * Controls the scoping behavior.
@@ -39,7 +50,7 @@ export interface CSSModulesOptions {
   /**
    * Transform convention for exported class names.
    */
-  localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
+  localsConvention?: CSSModulesLocalsConvention
 
   /**
    * Whether to include global class names in the export.

--- a/packages/css/src/plugin.ts
+++ b/packages/css/src/plugin.ts
@@ -178,6 +178,7 @@ export function CssPlugin(
             modules = applyLocalsConvention(
               modules,
               modulesConfig.localsConvention,
+              cleanId,
             )
           }
           modulesConfig?.getJSON?.(cleanId, modules, cleanId)


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

`css.modules.localsConvention` only accepted the four string presets, so projects migrating from Vite that pass a function to derive export names had no way to keep that behavior. This lets it also accept a function, matching Vite's signature `(originalClassName, generatedClassName, inputFile) => string`. The existing string conventions are unchanged.

### Linked Issues

Closes #1034

### Additional context
