### PR TITLE
feat(report): add `summary` option to skip per-file size logs

### DIFF
--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -91,6 +91,7 @@ export interface ReportOptions {
   gzip?: boolean;
   brotli?: boolean;
   maxCompressSize?: number;
+  summary?: boolean;
 }
 export interface ResolvedDepsConfig extends Pick<DepsConfig, "neverBundle" | "resolveDepSubpath"> {
   alwaysBundle?: NoExternalFn;

--- a/src/features/report.test.ts
+++ b/src/features/report.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createLogger } from '../utils/logger.ts'
+import { outputReport, type ReportOptions } from './report.ts'
+import type { ResolvedConfig } from '../config/types.ts'
+import type { OutputChunk } from 'rolldown'
+
+function chunk(fileName: string, code: string): OutputChunk {
+  return {
+    type: 'chunk',
+    fileName,
+    code,
+    isEntry: true,
+  } as unknown as OutputChunk
+}
+
+async function report(report: ReportOptions) {
+  const info = vi.fn()
+  const config = {
+    cwd: '/cwd',
+    format: 'es',
+    nameLabel: undefined,
+    report,
+    logger: { ...createLogger(), info },
+  } as unknown as ResolvedConfig
+
+  await outputReport(
+    config,
+    [chunk('a.js', 'a'), chunk('b.js', 'bb')],
+    '/cwd/dist',
+  )
+  return info
+}
+
+describe('outputReport', () => {
+  test('logs each file plus the total by default', async () => {
+    const info = await report({ gzip: false })
+    expect(info).toHaveBeenCalledTimes(3)
+    expect(info.mock.calls.at(-1)!.join(' ')).toContain('2 files, total:')
+  })
+
+  test('logs only the total when summary is enabled', async () => {
+    const info = await report({ gzip: false, summary: true })
+    expect(info).toHaveBeenCalledTimes(1)
+    expect(info.mock.calls[0].join(' ')).toContain('2 files, total:')
+  })
+})

--- a/src/features/report.ts
+++ b/src/features/report.ts
@@ -49,12 +49,21 @@ export interface ReportOptions {
    * @default 1_000_000 // 1 MB
    */
   maxCompressSize?: number
+
+  /**
+   * Only report the total size, skipping the per-file breakdown.
+   * Useful for libraries that emit many files in unbundle mode.
+   *
+   * @default false
+   */
+  summary?: boolean
 }
 
 const defaultOptions = {
   gzip: true,
   brotli: false,
   maxCompressSize: 1_000_000,
+  summary: false,
 } as const satisfies Required<ReportOptions>
 
 export function ReportPlugin(
@@ -131,20 +140,22 @@ export async function outputReport(
   const formatLabel =
     isDualFormat && prettyFormat(cjsDts ? 'cjs' : config.format)
 
-  for (const size of sizes) {
-    const filenameColor = size.dts ? green : noop
-    const filename = path.normalize(size.filename)
+  if (!options.summary) {
+    for (const size of sizes) {
+      const filenameColor = size.dts ? green : noop
+      const filename = path.normalize(size.filename)
 
-    config.logger.info(
-      config.nameLabel,
-      formatLabel,
-      dim(outDir + path.sep) +
-        filenameColor((size.isEntry ? bold : noop)(filename)),
-      ` `.repeat(filenameLength - size.filename.length),
-      dim(size.rawText),
-      options.gzip && size.gzipText && dim`│ gzip: ${size.gzipText}`,
-      options.brotli && size.brotliText && dim`│ brotli: ${size.brotliText}`,
-    )
+      config.logger.info(
+        config.nameLabel,
+        formatLabel,
+        dim(outDir + path.sep) +
+          filenameColor((size.isEntry ? bold : noop)(filename)),
+        ` `.repeat(filenameLength - size.filename.length),
+        dim(size.rawText),
+        options.gzip && size.gzipText && dim`│ gzip: ${size.gzipText}`,
+        options.brotli && size.brotliText && dim`│ brotli: ${size.brotliText}`,
+      )
+    }
   }
 
   const totalSizeText = formatBytes(totalRaw)


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

Adds a `report.summary` option. When enabled, the size report skips the per-file breakdown and prints only the totals line. In unbundle mode a library can emit thousands of output files, and the per-file lines bury the total size beyond the terminal scrollback. The option defaults to `false`, so existing output is unchanged.

### Linked Issues

Fixes #1033

### Additional context
