### PR TITLE
fix(css): watch files imported via `@import`

### DIFF
--- a/packages/css/src/lightningcss.test.ts
+++ b/packages/css/src/lightningcss.test.ts
@@ -1,6 +1,10 @@
+import path from 'node:path'
 import { browserslistToTargets } from 'lightningcss'
 import { expect, test } from 'vitest'
+import { globalLogger } from '../../../src/utils/logger.ts'
+import { writeFixtures } from '../../../tests/utils.ts'
 import {
+  bundleWithLightningCSS,
   esbuildTargetToLightningCSS,
   transformWithLightningCSS,
 } from './lightningcss.ts'
@@ -56,4 +60,20 @@ test('transformWithLightningCSS omits the map by default', async () => {
     },
   )
   expect(result.map).toBeUndefined()
+})
+
+test('bundleWithLightningCSS tracks @import-ed files as dependencies', async (context) => {
+  const { testDir } = await writeFixtures(context, {
+    'styles.css': `@import './partial.css';`,
+    'partial.css': `body { color: red }`,
+  })
+
+  const result = await bundleWithLightningCSS(
+    path.join(testDir, 'styles.css'),
+    {
+      logger: globalLogger,
+    },
+  )
+
+  expect(result.deps).toContain(path.join(testDir, 'partial.css'))
 })

--- a/packages/css/src/lightningcss.ts
+++ b/packages/css/src/lightningcss.ts
@@ -101,6 +101,9 @@ export async function bundleWithLightningCSS(
     sourceMap: options.sourceMap,
     resolver: {
       async read(filePath: string) {
+        if (filePath !== filename) {
+          deps.push(filePath)
+        }
         let fileCode: string
         if (code != null && filePath === filename) {
           fileCode = code


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

In watch mode, changing a CSS file that an entry stylesheet pulls in through `@import` did not trigger a rebuild, even though changing the entry stylesheet itself did. The LightningCSS transformer resolves and reads those imports through a custom resolver, but it only collected dependencies emitted by preprocessors, so plain CSS partials were never registered as watch files. This tracks every file the resolver reads, apart from the entry that Rolldown already watches, so edits to imported partials now rebuild.

### Linked Issues

Fixes #1037

### Additional context

Added a unit test that builds a stylesheet importing a partial and checks the partial is reported as a dependency. It fails on `main` and passes with this change.
