### PR TITLE
fix(exports): scope inlined dependencies to configs with exports

### DIFF
--- a/src/features/pkg/index.ts
+++ b/src/features/pkg/index.ts
@@ -80,10 +80,9 @@ export async function bundleDone(
     }
 
     const chunks: ChunksByFormat = {}
-    const inlinedDeps = mergeInlinedDeps(ctx.bundles)
-    for (const bundle of ctx.bundles) {
-      if (!bundle.config.exports) continue
-
+    const exportsBundles = ctx.bundles.filter((bundle) => bundle.config.exports)
+    const inlinedDeps = mergeInlinedDeps(exportsBundles)
+    for (const bundle of exportsBundles) {
       chunks[bundle.config.format] ||= []
       chunks[bundle.config.format]!.push(...bundle.chunks)
     }

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -7,7 +7,6 @@ import {
   type InlineConfig,
   type UserConfig,
 } from '../src/config/index.ts'
-import { build } from '../src/index.ts'
 import { slash } from '../src/utils/general.ts'
 import { globalLogger } from '../src/utils/logger.ts'
 import { chdir, testBuild, writeFixtures } from './utils.ts'
@@ -541,16 +540,18 @@ describe('deps', () => {
     })
 
     test('should not include inlined deps from configs without exports', async (context) => {
-      const { testDir } = await writeFixtures(context, {
-        ...node_modules,
-        'index.ts': `export { lib } from 'my-lib'`,
-        'standalone.ts': `import { lib } from 'my-lib'\nconsole.log(lib)`,
-        'package.json': JSON.stringify({
-          name: 'test-pkg',
-          version: '1.0.0',
-          dependencies: { 'my-lib': '1.2.3' },
-        }),
-        'tsdown.config.ts': `export default [
+      const { testDir } = await testBuild({
+        context,
+        files: {
+          ...node_modules,
+          'index.ts': `export { lib } from 'my-lib'`,
+          'standalone.ts': `import { lib } from 'my-lib'\nconsole.log(lib)`,
+          'package.json': JSON.stringify({
+            name: 'test-pkg',
+            version: '1.0.0',
+            dependencies: { 'my-lib': '1.2.3' },
+          }),
+          'tsdown.config.ts': `export default [
           { entry: ['index.ts'], format: ['esm'], exports: true, dts: false },
           {
             entry: ['standalone.ts'],
@@ -560,14 +561,14 @@ describe('deps', () => {
             deps: { alwaysBundle: [/.*/] },
           },
         ]`,
+        },
+        options: {
+          entry: undefined,
+          config: 'tsdown.config.ts',
+          dts: false,
+        },
+        snapshot: false,
       })
-
-      const restoreCwd = chdir(testDir)
-      try {
-        await build({ config: testDir, logLevel: 'silent' })
-      } finally {
-        restoreCwd()
-      }
 
       const pkg = JSON.parse(
         await readFile(path.join(testDir, 'package.json'), 'utf8'),

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -7,6 +7,7 @@ import {
   type InlineConfig,
   type UserConfig,
 } from '../src/config/index.ts'
+import { build } from '../src/index.ts'
 import { slash } from '../src/utils/general.ts'
 import { globalLogger } from '../src/utils/logger.ts'
 import { chdir, testBuild, writeFixtures } from './utils.ts'
@@ -532,6 +533,41 @@ describe('deps', () => {
         },
         snapshot: false,
       })
+
+      const pkg = JSON.parse(
+        await readFile(path.join(testDir, 'package.json'), 'utf8'),
+      )
+      expect(pkg.inlinedDependencies).toBeUndefined()
+    })
+
+    test('should not include inlined deps from configs without exports', async (context) => {
+      const { testDir } = await writeFixtures(context, {
+        ...node_modules,
+        'index.ts': `export { lib } from 'my-lib'`,
+        'standalone.ts': `import { lib } from 'my-lib'\nconsole.log(lib)`,
+        'package.json': JSON.stringify({
+          name: 'test-pkg',
+          version: '1.0.0',
+          dependencies: { 'my-lib': '1.2.3' },
+        }),
+        'tsdown.config.ts': `export default [
+          { entry: ['index.ts'], format: ['esm'], exports: true, dts: false },
+          {
+            entry: ['standalone.ts'],
+            format: ['cjs'],
+            outDir: 'dist/standalone',
+            dts: false,
+            deps: { alwaysBundle: [/.*/] },
+          },
+        ]`,
+      })
+
+      const restoreCwd = chdir(testDir)
+      try {
+        await build({ config: testDir, logLevel: 'silent' })
+      } finally {
+        restoreCwd()
+      }
 
       const pkg = JSON.parse(
         await readFile(path.join(testDir, 'package.json'), 'utf8'),


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.

### Description

When several build configs share one `package.json` and only some enable `exports`, the generated `inlinedDependencies` field pulled inlined deps from every config for that package, including ones that never contribute to the exports map. So a config that bundles everything (say a standalone binary excluded from `files`) leaked its inlined packages into the library's published `package.json`, even though the library externalizes those same packages.

The fix scopes the merge to the bundles the exports map is built from, so `inlinedDependencies` only lists deps that an exports config actually inlines.

### Linked Issues

Fixes #1039

### Additional context

Added a regression test with a two-config setup (one library config with `exports`, one bundle-everything config without) asserting the inlined dep from the second no longer appears in the package's `inlinedDependencies`.
