### PR TITLE
fix: make `deps.dts` optional

### DIFF
--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -228,7 +228,9 @@ export type ResolvedConfig = Overwrite<MarkPartial<Omit<UserConfig, "workspace" 
   nodeProtocol: "strip" | boolean;
   logger: Logger;
   ignoreWatch: Array<string | RegExp>;
-  deps: ResolvedDepsConfig;
+  deps: Omit<ResolvedDepsConfig, "dts"> & {
+    dts?: ResolvedDepsConfig["dts"];
+  };
   root: string;
   configDeps: Set<string>;
   runBuild: ConcurrencyExecutor;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -728,7 +728,7 @@ export type ResolvedConfig = Overwrite<
     nodeProtocol: 'strip' | boolean
     logger: Logger
     ignoreWatch: Array<string | RegExp>
-    deps: ResolvedDepsConfig
+    deps: Omit<ResolvedDepsConfig, 'dts'> & { dts?: ResolvedDepsConfig['dts'] }
     /**
      * Resolved root directory of input files
      */


### PR DESCRIPTION
This pull request makes a targeted update to the `ResolvedConfig` type in `src/config/types.ts` to improve type flexibility for the `deps` property. The change omits the `dts` property from `ResolvedDepsConfig` and reintroduces it as an optional property, allowing for more nuanced configuration.

- **Type flexibility improvement:**
  * Updated the `deps` property in the `ResolvedConfig` type to omit the `dts` property from `ResolvedDepsConfig` and redefine it as optional, enhancing configurability for dependency settings.