### PR TITLE
docs: add Ember support guide

### DIFF
--- a/docs/.vitepress/config/theme.ts
+++ b/docs/.vitepress/config/theme.ts
@@ -151,6 +151,7 @@ export function getLocaleConfig(lang: string) {
         { text: t('React Support'), link: '/react-support.md' },
         { text: t('Solid Support'), link: '/solid-support.md' },
         { text: t('Svelte Support'), link: '/svelte-support.md' },
+        { text: t('Ember Support'), link: '/ember-support.md' },
         { text: t('WASM Support'), link: '/wasm-support.md' },
       ],
     },

--- a/docs/.vitepress/i18n/translate-map.ts
+++ b/docs/.vitepress/i18n/translate-map.ts
@@ -40,6 +40,7 @@ const zhCN = {
   'React Support': 'React 支持',
   'Solid Support': 'Solid 支持',
   'Svelte Support': 'Svelte 支持',
+  'Ember Support': 'Ember 支持',
   'WASM Support': 'WASM 支持',
 
   Advanced: '高级功能',

--- a/docs/recipes/ember-support.md
+++ b/docs/recipes/ember-support.md
@@ -1,0 +1,103 @@
+# Ember Support
+
+`tsdown` supports building Ember v2 addons (libraries) by integrating [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown). This meta-plugin compiles `.gts`/`.gjs` and template-tag (`<template>`) sources into publishable output — a single `ember()` call replaces the usual stack of `@embroider/*` externals handling, `content-tag` preprocessing, and Babel wiring.
+
+## Minimal Example
+
+To configure `tsdown` for an Ember library, use the following setup in your `tsdown.config.ts`:
+
+```ts [tsdown.config.ts]
+import { ember } from '@nullvoxpopuli/ember-rolldown'
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  plugins: [ember()],
+})
+```
+
+Create a typical Ember component:
+
+```gts [src/components/badge.gts]
+import type { TOC } from '@ember/component/template-only'
+
+export interface BadgeSignature {
+  Args: { label: string }
+}
+
+export const Badge: TOC<BadgeSignature> = <template>
+  <span class="badge">{{@label}}</span>
+</template>
+```
+
+And export it from your entry file:
+
+```ts [src/index.ts]
+export { Badge } from './components/badge.gts'
+```
+
+This builds your entries to `dist/*.js` and `dist/*.d.ts` with sourcemaps, leaving Ember's virtual packages (e.g. `@ember/component`, `@glimmer/tracking`) and your `dependencies` / `peerDependencies` external for the consuming app to resolve.
+
+Install the required dependency:
+
+::: code-group
+
+```sh [npm]
+npm install -D @nullvoxpopuli/ember-rolldown
+```
+
+```sh [pnpm]
+pnpm add -D @nullvoxpopuli/ember-rolldown
+```
+
+```sh [yarn]
+yarn add -D @nullvoxpopuli/ember-rolldown
+```
+
+```sh [bun]
+bun add -D @nullvoxpopuli/ember-rolldown
+```
+
+:::
+
+> [!NOTE]
+> `@nullvoxpopuli/ember-rolldown` requires Node.js 24+ and TypeScript 6.
+
+## Declarations
+
+`.gts`/`.gjs` (template-tag) modules exist only inside the bundler's module graph, so declarations are emitted with [isolated declarations](../options/dts.md#with-isolateddeclarations) — the tsconfig your build uses must enable it (`ember()` errors otherwise):
+
+```jsonc [tsconfig.json]
+{
+  "compilerOptions": {
+    "isolatedDeclarations": true,
+  },
+}
+```
+
+This means every exported value carries an explicit type annotation, like the `TOC<BadgeSignature>` annotation above. If your package also contains dev-only code that shouldn't be constrained this way (a demo app, in-package tests), point tsdown's `tsconfig` option at a publish-only config:
+
+```ts [tsdown.config.ts]
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  tsconfig: './tsconfig.publish.json',
+  plugins: [ember()],
+})
+```
+
+## How It Works
+
+`ember()` returns a set of Rolldown plugins that:
+
+- Keep your `dependencies`, `peerDependencies`, and the Ember virtual packages external, so the consuming app resolves them.
+- Preprocess `<template>` tags via [`content-tag`](https://github.com/embroider-build/content-tag) and map `.gts`/`.gjs` modules so Rolldown understands them.
+- Run Babel only on the files that actually need it (template tags, decorators); everything else stays on Rolldown's fast native transforms.
+- Verify the tsconfig enables `isolatedDeclarations`.
+
+A Babel config is optional: without one, templates, decorators, and TypeScript are handled by built-in defaults; with one, your config runs instead.
+
+## CSS
+
+Components that import co-located CSS (`import './badge.css'`) require [`@tsdown/css`](../options/css.md); tsdown auto-detects it and bundles imported stylesheets into a single CSS file in `dist/`. Set `css: { inject: true }` to keep the CSS import statement in the output, so consuming apps load the styles through the module graph.
+
+For advanced topics — app re-exports for classic (name-based) resolution, `ember-scoped-css` integration, and publish-specific Babel configs — see the [plugin documentation](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown#readme).

--- a/docs/recipes/ember-support.md
+++ b/docs/recipes/ember-support.md
@@ -15,7 +15,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['./src/index.ts'],
-  dts: { sourcemap: true },
+  dts: true,
   plugins: [ember()],
 })
 ```
@@ -45,7 +45,7 @@ And export it from your entry file:
 export { Badge } from './components/badge.gts'
 ```
 
-The build writes `.js` and `.d.ts` files for each entry to `dist/`, along with their source maps. Ember virtual packages (such as `@ember/component` and `@glimmer/tracking`) and packages listed in `dependencies` or `peerDependencies` remain external and are resolved by the consuming app.
+The build writes `.js` and `.d.ts` files for each entry to `dist/` and emits source maps for the JavaScript output. Ember virtual packages (such as `@ember/component` and `@glimmer/tracking`) and packages listed in `dependencies` or `peerDependencies` remain external and are resolved by the consuming app.
 
 Install the required dependency:
 

--- a/docs/recipes/ember-support.md
+++ b/docs/recipes/ember-support.md
@@ -1,13 +1,13 @@
 # Ember Support
 
-`tsdown` supports building Ember v2 addons (libraries) by integrating [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown). This meta-plugin compiles `.gts`/`.gjs` and template-tag (`<template>`) sources into publishable output — a single `ember()` call replaces the usual stack of `@embroider/*` externals handling, `content-tag` preprocessing, and Babel wiring.
+`tsdown` can build Ember v2 addons (libraries) with [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown). This meta-plugin compiles `.gts` and `.gjs` files, including their `<template>` tags, into publishable output. A single `ember()` call replaces the usual `@embroider/*` externalization setup, `content-tag` preprocessing, and Babel integration.
 
 > [!NOTE]
-> The plugin currently targets Ember libraries (v2 addons) only — it hasn't been tested for building apps.
+> The plugin currently targets Ember libraries (v2 addons); building Ember apps has not been tested.
 
 ## Minimal Example
 
-To configure `tsdown` for an Ember library, use the following setup in your `tsdown.config.ts`:
+Configure an Ember library in `tsdown.config.ts` as follows:
 
 ```ts [tsdown.config.ts]
 import { ember } from '@nullvoxpopuli/ember-rolldown'
@@ -15,7 +15,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['./src/index.ts'],
-  dts: true,
+  dts: { sourcemap: true },
   plugins: [ember()],
 })
 ```
@@ -45,7 +45,7 @@ And export it from your entry file:
 export { Badge } from './components/badge.gts'
 ```
 
-This builds your entries to `dist/*.js` and `dist/*.d.ts` with sourcemaps, leaving Ember's virtual packages (e.g. `@ember/component`, `@glimmer/tracking`) and your `dependencies` / `peerDependencies` external for the consuming app to resolve.
+The build writes `.js` and `.d.ts` files for each entry to `dist/`, along with their source maps. Ember virtual packages (such as `@ember/component` and `@glimmer/tracking`) and packages listed in `dependencies` or `peerDependencies` remain external and are resolved by the consuming app.
 
 Install the required dependency:
 
@@ -70,11 +70,11 @@ bun add -D @nullvoxpopuli/ember-rolldown
 :::
 
 > [!NOTE]
-> `@nullvoxpopuli/ember-rolldown` requires Node.js 24+ and TypeScript 6.
+> `@nullvoxpopuli/ember-rolldown` requires Node.js 24+. Because the package ships TypeScript source, type-checking a project that uses it also requires TypeScript 6+ and a `lib` setting that includes `es2025` (for example, `esnext`).
 
 ## Declarations
 
-`.gts`/`.gjs` (template-tag) modules exist only inside the bundler's module graph, so declarations are emitted with [isolated declarations](../options/dts.md#with-isolateddeclarations) — the tsconfig your build uses must enable it (`ember()` errors otherwise):
+`.gts` and `.gjs` template-tag modules exist only in the bundler's module graph, so their declarations must be generated with [isolated declarations](../options/dts.md#with-isolateddeclarations). The `tsconfig` used for the build must enable `isolatedDeclarations`; otherwise, `ember()` reports an error:
 
 ```jsonc [tsconfig.json]
 {
@@ -84,7 +84,7 @@ bun add -D @nullvoxpopuli/ember-rolldown
 }
 ```
 
-This means every exported value carries an explicit type annotation, like the `TOC<BadgeSignature>` annotation above. If your package also contains dev-only code that shouldn't be constrained this way (a demo app, in-package tests), point tsdown's `tsconfig` option at a publish-only config:
+`isolatedDeclarations` requires sufficient type annotations on exports so declarations can be generated without cross-file type inference. For example, the component above uses the explicit `TOC<BadgeSignature>` type annotation. If your package also contains development-only code that should not be subject to this constraint, such as a demo app or in-package tests, point the `tsdown` `tsconfig` option to a publish-only config:
 
 ```ts [tsdown.config.ts]
 export default defineConfig({
@@ -98,15 +98,15 @@ export default defineConfig({
 
 `ember()` returns a set of Rolldown plugins that:
 
-- Keep your `dependencies`, `peerDependencies`, and the Ember virtual packages external, so the consuming app resolves them.
-- Preprocess `<template>` tags via [`content-tag`](https://github.com/embroider-build/content-tag) and map `.gts`/`.gjs` modules so Rolldown understands them.
-- Run Babel only on the files that actually need it (template tags, decorators); everything else stays on Rolldown's fast native transforms.
-- Verify the tsconfig enables `isolatedDeclarations`.
+- Keep packages from `dependencies` and `peerDependencies`, along with Ember virtual packages, external for the consuming app to resolve.
+- Preprocess `<template>` tags with [`content-tag`](https://github.com/embroider-build/content-tag) and map `.gts`/`.gjs` to `.ts`/`.js` so Rolldown can process them.
+- Run Babel only on files that need it, such as files with template tags or decorators. All other files use Rolldown's fast native transforms.
+- Verify that the `tsconfig` enables `isolatedDeclarations`.
 
-A Babel config is optional: without one, templates, decorators, and TypeScript are handled by built-in defaults; with one, your config runs instead.
+A Babel configuration is optional. Without one, `ember()` uses built-in defaults to handle templates, decorators, and TypeScript. If you provide one, `ember()` uses it instead.
 
 ## CSS
 
-Components that import co-located CSS (`import './badge.css'`) require [`@tsdown/css`](../options/css.md); tsdown auto-detects it and bundles imported stylesheets into a single CSS file in `dist/`. Set `css: { inject: true }` to keep the CSS import statement in the output, so consuming apps load the styles through the module graph.
+If a component imports co-located CSS (`import './badge.css'`), install [`@tsdown/css`](../options/css.md) in your project. `tsdown` detects the package automatically and bundles imported stylesheets into a single CSS file in `dist/`. Set `css: { inject: true }` to preserve an import for that generated CSS file in the JavaScript output, allowing consuming apps to load the styles through the module graph.
 
-For advanced topics — app re-exports for classic (name-based) resolution, `ember-scoped-css` integration, and publish-specific Babel configs — see the [plugin documentation](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown#readme).
+For advanced topics such as app re-exports for classic name-based resolution, `ember-scoped-css` integration, and publish-specific Babel configurations, see the [plugin documentation](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown#readme).

--- a/docs/recipes/ember-support.md
+++ b/docs/recipes/ember-support.md
@@ -12,6 +12,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  dts: true,
   plugins: [ember()],
 })
 ```
@@ -22,11 +23,16 @@ Create a typical Ember component:
 import type { TOC } from '@ember/component/template-only'
 
 export interface BadgeSignature {
+  Element: HTMLSpanElement
   Args: { label: string }
+  Blocks: { default: [] }
 }
 
 export const Badge: TOC<BadgeSignature> = <template>
-  <span class="badge">{{@label}}</span>
+  <span class="badge" ...attributes>
+    {{@label}}
+    {{yield}}
+  </span>
 </template>
 ```
 

--- a/docs/recipes/ember-support.md
+++ b/docs/recipes/ember-support.md
@@ -2,6 +2,9 @@
 
 `tsdown` supports building Ember v2 addons (libraries) by integrating [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown). This meta-plugin compiles `.gts`/`.gjs` and template-tag (`<template>`) sources into publishable output — a single `ember()` call replaces the usual stack of `@embroider/*` externals handling, `content-tag` preprocessing, and Babel wiring.
 
+> [!NOTE]
+> The plugin currently targets Ember libraries (v2 addons) only — it hasn't been tested for building apps.
+
 ## Minimal Example
 
 To configure `tsdown` for an Ember library, use the following setup in your `tsdown.config.ts`:

--- a/docs/zh-CN/recipes/ember-support.md
+++ b/docs/zh-CN/recipes/ember-support.md
@@ -1,13 +1,13 @@
 # Ember 支持
 
-`tsdown` 通过集成 [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown) 支持构建 Ember v2 addon（库）。这个元插件（meta-plugin）将 `.gts`/`.gjs` 及模板标签（`<template>`）源码编译为可发布的产物——只需一个 `ember()` 调用，即可取代原本由 `@embroider/*` 外部依赖处理、`content-tag` 预处理和 Babel 配置组成的一整套工具链。
+`tsdown` 可借助 [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown) 构建 Ember v2 addon（库）。该元插件会将 `.gts` 和 `.gjs` 文件（包括其中的 `<template>` 标签）编译为可发布的产物。只需调用一次 `ember()`，即可取代通常所需的 `@embroider/*` 外部化配置、`content-tag` 预处理和 Babel 集成。
 
 > [!NOTE]
-> 该插件目前仅面向 Ember 库（v2 addon）——尚未针对构建应用（app）进行测试。
+> 该插件目前仅面向 Ember 库（v2 addon）；尚未测试 Ember 应用的构建。
 
 ## 最简示例
 
-要为 Ember 库配置 `tsdown`，请在 `tsdown.config.ts` 中使用以下配置：
+在 `tsdown.config.ts` 中按如下方式配置 Ember 库：
 
 ```ts [tsdown.config.ts]
 import { ember } from '@nullvoxpopuli/ember-rolldown'
@@ -15,7 +15,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['./src/index.ts'],
-  dts: true,
+  dts: { sourcemap: true },
   plugins: [ember()],
 })
 ```
@@ -45,7 +45,7 @@ export const Badge: TOC<BadgeSignature> = <template>
 export { Badge } from './components/badge.gts'
 ```
 
-该配置会将您的入口构建为带有 sourcemap 的 `dist/*.js` 和 `dist/*.d.ts`，同时将 Ember 的虚拟包（如 `@ember/component`、`@glimmer/tracking`）以及您的 `dependencies` / `peerDependencies` 保持为外部依赖，由使用方应用解析。
+构建后会在 `dist/` 中生成与各入口对应的 `.js` 和 `.d.ts` 文件及其源映射。Ember 虚拟包（如 `@ember/component` 和 `@glimmer/tracking`）以及列在 `dependencies` 或 `peerDependencies` 中的包不会被打包，而由使用该库的应用解析。
 
 安装所需依赖：
 
@@ -70,11 +70,11 @@ bun add -D @nullvoxpopuli/ember-rolldown
 :::
 
 > [!NOTE]
-> `@nullvoxpopuli/ember-rolldown` 需要 Node.js 24+ 和 TypeScript 6。
+> `@nullvoxpopuli/ember-rolldown` 需要 Node.js 24+。由于该包直接发布 TypeScript 源码，如需对使用该包的项目进行类型检查，还需使用 TypeScript 6+，并在 `lib` 中包含 `es2025`（例如 `esnext`）。
 
 ## 声明文件
 
-`.gts`/`.gjs`（模板标签）模块仅存在于打包器的模块图中，因此声明文件通过[隔离声明（isolated declarations）](../options/dts.md#启用-isolateddeclarations)生成——构建所使用的 tsconfig 必须启用该选项（否则 `ember()` 会报错）：
+`.gts` 和 `.gjs` 这类模板标签模块只存在于打包器的模块图中，因此必须使用 [`isolatedDeclarations`](../options/dts.md#启用-isolateddeclarations) 生成声明文件。构建所用的 `tsconfig` 必须启用该选项，否则 `ember()` 会报错：
 
 ```jsonc [tsconfig.json]
 {
@@ -84,7 +84,7 @@ bun add -D @nullvoxpopuli/ember-rolldown
 }
 ```
 
-这意味着每个导出的值都需要显式的类型注解，例如上文的 `TOC<BadgeSignature>`。如果您的包中还包含不应受此约束的仅供开发的代码（例如包内的演示应用或测试），可将 tsdown 的 `tsconfig` 选项指向仅用于发布的配置文件：
+`isolatedDeclarations` 要求为导出的 API 提供足够的类型标注，使工具无需跨文件类型推断即可生成声明文件。例如，上文的组件使用了显式的 `TOC<BadgeSignature>` 类型注解。如果包内还包含不应受此约束的仅供开发的代码（如演示应用或包内测试），可将 `tsdown` 的 `tsconfig` 选项指向仅用于发布的配置文件：
 
 ```ts [tsdown.config.ts]
 export default defineConfig({
@@ -98,15 +98,15 @@ export default defineConfig({
 
 `ember()` 返回一组 Rolldown 插件，它们会：
 
-- 将您的 `dependencies`、`peerDependencies` 以及 Ember 虚拟包保持为外部依赖，由使用方应用解析。
-- 通过 [`content-tag`](https://github.com/embroider-build/content-tag) 预处理 `<template>` 标签，并映射 `.gts`/`.gjs` 模块，使 Rolldown 能够识别它们。
-- 仅对真正需要的文件（模板标签、装饰器）运行 Babel；其余文件仍使用 Rolldown 快速的原生转换。
-- 校验 tsconfig 是否启用了 `isolatedDeclarations`。
+- 将 `dependencies` 和 `peerDependencies` 中的包以及 Ember 虚拟包保留为外部依赖，由使用该库的应用解析。
+- 使用 [`content-tag`](https://github.com/embroider-build/content-tag) 预处理 `<template>` 标签，并将 `.gts`/`.gjs` 映射为 `.ts`/`.js`，使 Rolldown 能够处理它们。
+- 仅对包含模板标签、装饰器等确需 Babel 处理的文件运行 Babel；其他文件仍使用 Rolldown 的快速原生转换。
+- 检查构建所用的 `tsconfig` 是否启用了 `isolatedDeclarations`。
 
-Babel 配置是可选的：没有配置时，模板、装饰器和 TypeScript 由内置默认值处理；有配置时，则使用您的配置。
+Babel 配置可省略。未提供时，`ember()` 会使用内置默认配置处理模板、装饰器和 TypeScript；提供后则改用自定义配置。
 
 ## CSS
 
-导入同目录 CSS 的组件（`import './badge.css'`）需要安装 [`@tsdown/css`](../options/css.md)；tsdown 会自动检测并将导入的样式表打包为 `dist/` 中的单个 CSS 文件。设置 `css: { inject: true }` 可在产物中保留 CSS 导入语句，使使用方应用通过模块图加载样式。
+若组件导入了与其同目录的 CSS（`import './badge.css'`），项目需安装 [`@tsdown/css`](../options/css.md)。`tsdown` 会自动检测该包，并将导入的样式表合并到 `dist/` 中的一个 CSS 文件。设置 `css: { inject: true }` 后，生成的 JavaScript 会保留指向该 CSS 文件的导入语句，使用该库的应用便可通过模块图加载样式。
 
-关于更多高级主题——用于经典（基于名称）解析的应用再导出（app re-exports）、`ember-scoped-css` 集成以及发布专用的 Babel 配置——请参阅[插件文档](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown#readme)。
+如需了解用于支持经典名称解析的 `app re-exports`、`ember-scoped-css` 集成和发布专用 Babel 配置等高级用法，请参阅[插件文档](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown#readme)。

--- a/docs/zh-CN/recipes/ember-support.md
+++ b/docs/zh-CN/recipes/ember-support.md
@@ -2,6 +2,9 @@
 
 `tsdown` 通过集成 [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown) 支持构建 Ember v2 addon（库）。这个元插件（meta-plugin）将 `.gts`/`.gjs` 及模板标签（`<template>`）源码编译为可发布的产物——只需一个 `ember()` 调用，即可取代原本由 `@embroider/*` 外部依赖处理、`content-tag` 预处理和 Babel 配置组成的一整套工具链。
 
+> [!NOTE]
+> 该插件目前仅面向 Ember 库（v2 addon）——尚未针对构建应用（app）进行测试。
+
 ## 最简示例
 
 要为 Ember 库配置 `tsdown`，请在 `tsdown.config.ts` 中使用以下配置：

--- a/docs/zh-CN/recipes/ember-support.md
+++ b/docs/zh-CN/recipes/ember-support.md
@@ -1,0 +1,103 @@
+# Ember 支持
+
+`tsdown` 通过集成 [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown) 支持构建 Ember v2 addon（库）。这个元插件（meta-plugin）将 `.gts`/`.gjs` 及模板标签（`<template>`）源码编译为可发布的产物——只需一个 `ember()` 调用，即可取代原本由 `@embroider/*` 外部依赖处理、`content-tag` 预处理和 Babel 配置组成的一整套工具链。
+
+## 最简示例
+
+要为 Ember 库配置 `tsdown`，请在 `tsdown.config.ts` 中使用以下配置：
+
+```ts [tsdown.config.ts]
+import { ember } from '@nullvoxpopuli/ember-rolldown'
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  plugins: [ember()],
+})
+```
+
+创建一个典型的 Ember 组件：
+
+```gts [src/components/badge.gts]
+import type { TOC } from '@ember/component/template-only'
+
+export interface BadgeSignature {
+  Args: { label: string }
+}
+
+export const Badge: TOC<BadgeSignature> = <template>
+  <span class="badge">{{@label}}</span>
+</template>
+```
+
+然后在入口文件中导出它：
+
+```ts [src/index.ts]
+export { Badge } from './components/badge.gts'
+```
+
+该配置会将您的入口构建为带有 sourcemap 的 `dist/*.js` 和 `dist/*.d.ts`，同时将 Ember 的虚拟包（如 `@ember/component`、`@glimmer/tracking`）以及您的 `dependencies` / `peerDependencies` 保持为外部依赖，由使用方应用解析。
+
+安装所需依赖：
+
+::: code-group
+
+```sh [npm]
+npm install -D @nullvoxpopuli/ember-rolldown
+```
+
+```sh [pnpm]
+pnpm add -D @nullvoxpopuli/ember-rolldown
+```
+
+```sh [yarn]
+yarn add -D @nullvoxpopuli/ember-rolldown
+```
+
+```sh [bun]
+bun add -D @nullvoxpopuli/ember-rolldown
+```
+
+:::
+
+> [!NOTE]
+> `@nullvoxpopuli/ember-rolldown` 需要 Node.js 24+ 和 TypeScript 6。
+
+## 声明文件
+
+`.gts`/`.gjs`（模板标签）模块仅存在于打包器的模块图中，因此声明文件通过[隔离声明（isolated declarations）](../options/dts.md#启用-isolateddeclarations)生成——构建所使用的 tsconfig 必须启用该选项（否则 `ember()` 会报错）：
+
+```jsonc [tsconfig.json]
+{
+  "compilerOptions": {
+    "isolatedDeclarations": true,
+  },
+}
+```
+
+这意味着每个导出的值都需要显式的类型注解，例如上文的 `TOC<BadgeSignature>`。如果您的包中还包含不应受此约束的仅供开发的代码（例如包内的演示应用或测试），可将 tsdown 的 `tsconfig` 选项指向仅用于发布的配置文件：
+
+```ts [tsdown.config.ts]
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  tsconfig: './tsconfig.publish.json',
+  plugins: [ember()],
+})
+```
+
+## 工作原理
+
+`ember()` 返回一组 Rolldown 插件，它们会：
+
+- 将您的 `dependencies`、`peerDependencies` 以及 Ember 虚拟包保持为外部依赖，由使用方应用解析。
+- 通过 [`content-tag`](https://github.com/embroider-build/content-tag) 预处理 `<template>` 标签，并映射 `.gts`/`.gjs` 模块，使 Rolldown 能够识别它们。
+- 仅对真正需要的文件（模板标签、装饰器）运行 Babel；其余文件仍使用 Rolldown 快速的原生转换。
+- 校验 tsconfig 是否启用了 `isolatedDeclarations`。
+
+Babel 配置是可选的：没有配置时，模板、装饰器和 TypeScript 由内置默认值处理；有配置时，则使用您的配置。
+
+## CSS
+
+导入同目录 CSS 的组件（`import './badge.css'`）需要安装 [`@tsdown/css`](../options/css.md)；tsdown 会自动检测并将导入的样式表打包为 `dist/` 中的单个 CSS 文件。设置 `css: { inject: true }` 可在产物中保留 CSS 导入语句，使使用方应用通过模块图加载样式。
+
+关于更多高级主题——用于经典（基于名称）解析的应用再导出（app re-exports）、`ember-scoped-css` 集成以及发布专用的 Babel 配置——请参阅[插件文档](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown#readme)。

--- a/docs/zh-CN/recipes/ember-support.md
+++ b/docs/zh-CN/recipes/ember-support.md
@@ -15,7 +15,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['./src/index.ts'],
-  dts: { sourcemap: true },
+  dts: true,
   plugins: [ember()],
 })
 ```
@@ -45,7 +45,7 @@ export const Badge: TOC<BadgeSignature> = <template>
 export { Badge } from './components/badge.gts'
 ```
 
-构建后会在 `dist/` 中生成与各入口对应的 `.js` 和 `.d.ts` 文件及其源映射。Ember 虚拟包（如 `@ember/component` 和 `@glimmer/tracking`）以及列在 `dependencies` 或 `peerDependencies` 中的包不会被打包，而由使用该库的应用解析。
+构建后会在 `dist/` 中生成与各入口对应的 `.js` 和 `.d.ts` 文件，并为 JavaScript 产物生成源映射。Ember 虚拟包（如 `@ember/component` 和 `@glimmer/tracking`）以及列在 `dependencies` 或 `peerDependencies` 中的包不会被打包，而由使用该库的应用解析。
 
 安装所需依赖：
 

--- a/docs/zh-CN/recipes/ember-support.md
+++ b/docs/zh-CN/recipes/ember-support.md
@@ -12,6 +12,7 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  dts: true,
   plugins: [ember()],
 })
 ```
@@ -22,11 +23,16 @@ export default defineConfig({
 import type { TOC } from '@ember/component/template-only'
 
 export interface BadgeSignature {
+  Element: HTMLSpanElement
   Args: { label: string }
+  Blocks: { default: [] }
 }
 
 export const Badge: TOC<BadgeSignature> = <template>
-  <span class="badge">{{@label}}</span>
+  <span class="badge" ...attributes>
+    {{@label}}
+    {{yield}}
+  </span>
 </template>
 ```
 


### PR DESCRIPTION
## Description

Adds an "Ember Support" recipe to the docs, alongside the existing Vue / React / Solid / Svelte recipes, covering how to build Ember v2 addons (libraries) with tsdown via [`@nullvoxpopuli/ember-rolldown`](https://github.com/NullVoxPopuli/ember.nvp/tree/main/packages/rolldown).

The recipe covers:

- A minimal `tsdown.config.ts` with the `ember()` meta-plugin, plus a `.gts` (template-tag) example component
- Declarations for `.gts`/`.gjs` modules via isolated declarations (with a pointer to a publish-only tsconfig for packages with dev-only code)
- What `ember()` does (externals for Ember virtual packages, `content-tag` preprocessing, scoped Babel usage)
- Co-located CSS via `@tsdown/css`

Changes:

- `docs/recipes/ember-support.md` + `docs/zh-CN/recipes/ember-support.md`
- Sidebar entry in `docs/.vitepress/config/theme.ts` and translation in `docs/.vitepress/i18n/translate-map.ts`

The example in the recipe was verified end-to-end against `tsdown@0.22.14` + `@nullvoxpopuli/ember-rolldown@2.6.0` (templates compile to `precompileTemplate`, Ember virtual packages stay external, `.d.ts` emitted correctly), and `pnpm docs:build` passes with the `gts` code fences highlighting via Shiki's `glimmer-ts` grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
