### PR TITLE
fix(css): keep the emitted .map asset aligned when css.inject prepends the import

### DIFF
--- a/packages/css/src/plugin.ts
+++ b/packages/css/src/plugin.ts
@@ -27,7 +27,7 @@ import {
   toCssFileName,
 } from './utils.ts'
 import type { CSSModulesConfig } from 'lightningcss'
-import type { Plugin } from 'rolldown'
+import type { OutputBundle, OutputChunk, Plugin } from 'rolldown'
 import type { ResolvedConfig } from 'tsdown'
 import type { Logger } from 'tsdown/internal'
 
@@ -304,33 +304,14 @@ export function CssPlugin(
             // Direct CSS modules in this chunk need a prepended import
             if (chunk.moduleIds.some((id) => styles.has(id))) {
               const cssFile = toCssFileName(chunk.fileName)
-              const relativePath = path.posix.relative(
-                path.posix.dirname(chunk.fileName),
-                cssFile,
-              )
-              const importPath =
-                relativePath[0] === '.' ? relativePath : `./${relativePath}`
-              chunk.code = `import '${importPath}';\n${chunk.code}`
-              if (chunk.map) {
-                chunk.map.mappings = `;${chunk.map.mappings}`
-              }
+              prependCssImport(bundle, chunk, cssFile)
             }
           } else {
             const hasCss =
               chunk.moduleIds.some((id) => styles.has(id)) ||
               chunk.imports.some((imp) => pureCssChunks.has(imp))
             if (hasCss) {
-              const cssFile = cssConfig.css.fileName
-              const relativePath = path.posix.relative(
-                path.posix.dirname(chunk.fileName),
-                cssFile,
-              )
-              const importPath =
-                relativePath[0] === '.' ? relativePath : `./${relativePath}`
-              chunk.code = `import '${importPath}';\n${chunk.code}`
-              if (chunk.map) {
-                chunk.map.mappings = `;${chunk.map.mappings}`
-              }
+              prependCssImport(bundle, chunk, cssConfig.css.fileName)
             }
           }
         }
@@ -500,6 +481,37 @@ async function processWithPostCSS(
     code: transformResult.code,
     map: transformResult.map ?? postcssResult.map,
     modules: postcssResult.modules,
+  }
+}
+
+/**
+ * Prepends `import '<css file>'` to a chunk, keeping its sourcemap aligned.
+ *
+ * The one-line prepend is compensated by prefixing the mappings with `;`.
+ * rolldown materializes the companion `.map` asset before `generateBundle`
+ * runs and does not propagate `chunk.map` mutations into it (unlike rollup,
+ * see https://github.com/rolldown/rolldown/issues/10676), so the asset is
+ * refreshed here too -- otherwise every mapping in the emitted map is one
+ * line early.
+ */
+function prependCssImport(
+  bundle: OutputBundle,
+  chunk: OutputChunk,
+  cssFile: string,
+): void {
+  const relativePath = path.posix.relative(
+    path.posix.dirname(chunk.fileName),
+    cssFile,
+  )
+  const importPath =
+    relativePath[0] === '.' ? relativePath : `./${relativePath}`
+  chunk.code = `import '${importPath}';\n${chunk.code}`
+  if (chunk.map) {
+    chunk.map.mappings = `;${chunk.map.mappings}`
+    const mapAsset = bundle[`${chunk.fileName}.map`]
+    if (mapAsset?.type === 'asset') {
+      mapAsset.source = JSON.stringify(chunk.map)
+    }
   }
 }
 

--- a/tests/__snapshots__/sourcemap/css-inject-keeps-the-emitted-map-aligned-with-the-injected-import.snap.md
+++ b/tests/__snapshots__/sourcemap/css-inject-keeps-the-emitted-map-aligned-with-the-injected-import.snap.md
@@ -1,0 +1,26 @@
+## index.mjs
+
+```mjs
+import './style.css';
+//#region index.ts
+const value = 42;
+//#endregion
+export { value };
+
+//# sourceMappingURL=index.mjs.map
+```
+
+## index.mjs.map
+
+```map
+{"version":3,"file":"index.mjs","names":[],"sources":["../index.ts"],"sourcesContent":["import './foo.css'\nexport const value = 42"],"mappings":";;AACA,MAAa,QAAQ"}
+```
+
+## style.css
+
+```css
+body {
+  color: red;
+}
+
+```

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -1807,6 +1807,11 @@ describe('css', () => {
       let value = 0
       for (const char of segment) {
         const digit = BASE64_CHARS.indexOf(char)
+        if (digit === -1) {
+          throw new Error(
+            `invalid base64 VLQ character ${JSON.stringify(char)} in segment ${JSON.stringify(segment)}`,
+          )
+        }
         value += (digit & 31) << shift
         if (digit & 32) {
           shift += 5
@@ -1815,6 +1820,11 @@ describe('css', () => {
           shift = 0
           value = 0
         }
+      }
+      if (shift !== 0) {
+        throw new Error(
+          `dangling VLQ continuation in segment ${JSON.stringify(segment)}`,
+        )
       }
       return fields
     }

--- a/tests/css.test.ts
+++ b/tests/css.test.ts
@@ -1798,6 +1798,71 @@ describe('css', () => {
       expect(outputFiles).toContain('index.mjs.map')
     })
 
+    const BASE64_CHARS =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+    function decodeVlqSegment(segment: string): number[] {
+      const fields: number[] = []
+      let shift = 0
+      let value = 0
+      for (const char of segment) {
+        const digit = BASE64_CHARS.indexOf(char)
+        value += (digit & 31) << shift
+        if (digit & 32) {
+          shift += 5
+        } else {
+          fields.push(value & 1 ? -(value >>> 1) : value >>> 1)
+          shift = 0
+          value = 0
+        }
+      }
+      return fields
+    }
+
+    /** 1-based original line the first segment of `generatedLine` maps to. */
+    function originalLineFor(
+      mappings: string,
+      generatedLine: number,
+    ): number | null {
+      let sourceLine = 0
+      const lines = mappings.split(';')
+      for (const [index, line] of lines.entries()) {
+        const segments = line ? line.split(',') : []
+        for (const [segmentIndex, segment] of segments.entries()) {
+          const fields = decodeVlqSegment(segment)
+          if (fields.length >= 4) sourceLine += fields[2]
+          if (index + 1 === generatedLine && segmentIndex === 0) {
+            return fields.length >= 4 ? sourceLine + 1 : null
+          }
+        }
+        if (index + 1 === generatedLine && segments.length === 0) return null
+      }
+      return null
+    }
+
+    test('css.inject keeps the emitted map aligned with the injected import', async (context) => {
+      const { fileMap } = await testBuild({
+        context,
+        files: {
+          'index.ts': `import './foo.css'\nexport const value = 42`,
+          'foo.css': `body { color: red }`,
+        },
+        options: { sourcemap: true, css: { inject: true } },
+      })
+
+      const code = fileMap['index.mjs']
+      expect(code.startsWith(`import './style.css';`)).toBe(true)
+
+      // `export const value = 42` is line 2 of index.ts. The injected css
+      // import shifts it down one generated line; the *emitted* map must
+      // follow (rolldown materializes the .map asset before generateBundle,
+      // so mutating chunk.map alone is not enough).
+      const generatedLine =
+        code.split('\n').findIndex((line) => line.includes('const value')) + 1
+      const map = JSON.parse(fileMap['index.mjs.map'])
+      expect(originalLineFor(map.mappings, generatedLine)).toBe(2)
+    })
+
     test('inline css does not warn SOURCEMAP_BROKEN', async (context) => {
       const { outputFiles, warnings } = await testBuild({
         context,


### PR DESCRIPTION
`css.inject` prepends `import './style.css';` to styled chunks in `generateBundle` and compensates `chunk.map` with a `;` mappings prefix. that compensation is correct — but rolldown materializes the companion `.map` asset *before* `generateBundle` runs and doesn't propagate `chunk.map` mutations into it (rolldown/rolldown#10676). so the emitted map is one line behind the emitted code, and every mapping in every css-injecting chunk points one line early.

found this while testing sourcemap alignment for ember-scoped-css's tsdown build — every component in the bundle was misaligned, cascading (in [this kind of visualization](https://evanw.github.io/source-map-visualization/), each statement highlights the line above itself).

the fix: extract the duplicated prepend logic into `prependCssImport()`, which also refreshes the `.map` asset from the mutated `chunk.map`. works with today's rolldown; harmless if rolldown starts syncing the asset itself.

the test decodes the mappings VLQ inline (no new dependency) and asserts `export const value = 42` traces to its exact original line through the injected import. red without the fix, green with it.

---

*Disclosure: this investigation, fix, and write-up are AI-assisted exploration (Claude Fable 5 via Claude Code), directed and reviewed by me.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
