### PR TITLE
fix(deps): apply `resolveDepSubpath` when `neverBundle` is `true`

### DIFF
--- a/docs/options/dependencies.md
+++ b/docs/options/dependencies.md
@@ -140,7 +140,7 @@ export default defineConfig({
 
 When enabled, every import that follows npm package naming conventions (e.g. `lodash`, `@scope/pkg/utils`) is marked as external **as written, without being resolved**. This is fast and even works when dependencies are not installed. Note the following behaviors:
 
-- Package specifiers are preserved exactly as written; subpaths like `my-dep/utils` are not rewritten, and `resolveDepSubpath` has no effect.
+- Package specifiers are preserved exactly as written; subpaths like `my-dep/utils` are only rewritten when `resolveDepSubpath` is enabled.
 - Other non-relative imports — [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) starting with `#` and path aliases like `~/utils` — are still resolved: if they resolve into `node_modules`, they are kept external with the original specifier; otherwise the resolved local file is bundled.
 
 `neverBundle: true` can be combined with `alwaysBundle` to bundle a few selected dependencies while externalizing everything else:

--- a/docs/zh-CN/options/dependencies.md
+++ b/docs/zh-CN/options/dependencies.md
@@ -140,7 +140,7 @@ export default defineConfig({
 
 启用后，所有符合 npm 包名规范的导入（例如 `lodash`、`@scope/pkg/utils`）都会**按原样标记为外部依赖，不会进行解析**。这一过程非常快速，即使依赖没有安装也能正常工作。请注意以下行为：
 
-- 包说明符会按原样保留；`my-dep/utils` 这类子路径不会被改写，`resolveDepSubpath` 选项不生效。
+- 包说明符会按原样保留；`my-dep/utils` 这类子路径仅在启用 `resolveDepSubpath` 时才会被改写。
 - 其他非相对导入——以 `#` 开头的[子路径导入](https://nodejs.org/api/packages.html#subpath-imports)和 `~/utils` 这类路径别名——仍会被解析：如果解析结果位于 `node_modules` 中，则保留原始说明符并外部化；否则打包解析到的本地文件。
 
 `neverBundle: true` 可以与 `alwaysBundle` 组合使用，在外部化其他所有依赖的同时打包少数指定依赖：

--- a/skills/tsdown/references/option-dependencies.md
+++ b/skills/tsdown/references/option-dependencies.md
@@ -68,7 +68,7 @@ export default defineConfig({
 })
 ```
 
-**Result:** Every import that follows npm package naming conventions is externalized as written, without being resolved. This is fast and even works when dependencies are not installed. Subpaths like `my-dep/utils` are preserved exactly (`resolveDepSubpath` has no effect). Other non-relative imports (`#` subpath imports, path aliases like `~/`) are resolved: they stay external if they resolve into node_modules, and are bundled if they map to local files. Combine with `alwaysBundle` to bundle selected dependencies.
+**Result:** Every import that follows npm package naming conventions is externalized as written, without being resolved. This is fast and even works when dependencies are not installed. Subpaths like `my-dep/utils` are preserved exactly unless `resolveDepSubpath` is enabled. Other non-relative imports (`#` subpath imports, path aliases like `~/`) are resolved: they stay external if they resolve into node_modules, and are bundled if they map to local files. Combine with `alwaysBundle` to bundle selected dependencies.
 
 ### `deps.alwaysBundle`
 

--- a/src/features/deps.ts
+++ b/src/features/deps.ts
@@ -376,8 +376,13 @@ export function DepsPlugin(
       if (id[0] === '\0' || id.startsWith('data:') || path.isAbsolute(id)) {
         return false
       }
-      if (isBuiltin(id) || RE_PACKAGE_SPECIFIER.test(id)) {
+      if (isBuiltin(id)) {
         return true
+      }
+      if (RE_PACKAGE_SPECIFIER.test(id)) {
+        const resolvedDep =
+          shouldResolveDepSubpath && (await resolveDepSubpath(id, resolve))
+        return resolvedDep ? [true, resolvedDep] : true
       }
       const resolved = await resolve()
       return (

--- a/src/features/deps.ts
+++ b/src/features/deps.ts
@@ -364,7 +364,8 @@ export function DepsPlugin(
     }
 
     // `neverBundle: true`: imports that follow npm package naming
-    // conventions are externalized as written, without resolving them.
+    // conventions are externalized as written, without resolving them
+    // unless `resolveDepSubpath` rewrites the subpath.
     // Anything else (`#` subpath imports, path aliases like `~/` or `@/`)
     // may map to local files, so it is resolved and kept external only if
     // it lands in `node_modules`.

--- a/tests/__snapshots__/neverBundle-true/resolveDepSubpath-resolves-subpaths.snap.md
+++ b/tests/__snapshots__/neverBundle-true/resolveDepSubpath-resolves-subpaths.snap.md
@@ -1,0 +1,7 @@
+## index.mjs
+
+```mjs
+import { lt } from "my-dep/functions/lt.js";
+export { lt };
+
+```

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1509,6 +1509,21 @@ export { local } from './local'`,
     expect(fileMap['index.mjs']).toContain('local = 1')
   })
 
+  test('resolveDepSubpath resolves subpaths', async (context) => {
+    const { fileMap } = await testBuild({
+      context,
+      files: {
+        ...node_modules,
+        'index.ts': `export { lt } from 'my-dep/functions/lt'`,
+      },
+      options: {
+        deps: { neverBundle: true, resolveDepSubpath: true },
+      },
+    })
+
+    expect(fileMap['index.mjs']).toContain('my-dep/functions/lt.js')
+  })
+
   test('# subpath imports are resolved', async (context) => {
     const { fileMap } = await testBuild({
       context,


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
- [ ] AI was used: <!-- e.g. Codex + GPT 5.6 Sol Extra High -->
  - [ ] I have carefully reviewed the AI-generated content myself.

### Description

With `deps.neverBundle: true`, anything matching npm package naming is externalized exactly as written, so `deps.resolveDepSubpath: true` had no effect on those specifiers. Importing something like `source-map-support/register` from a package without an `exports` field then left an extensionless specifier in the ESM output, which Node cannot resolve. The old `skipNodeModulesBundle` did resolve it, so the replacement option is a regression for that case.

Package specifiers now go through the same subpath resolution the regular external path already uses, but only when `resolveDepSubpath` is enabled. With the option off (the default) nothing is resolved, so the fast path stays as it is.

### Linked Issues

Fixes #1052

### Additional context

The new e2e test fails on `main` and passes here. Docs and the skill reference said `resolveDepSubpath` has no effect under `neverBundle: true`, so both are updated.
