### PR TITLE
fix(cli): apply `--deps.never-bundle` by camel-casing dotted flag keys

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest'
+import { cli, normalizeFlags } from './cli.ts'
+import type { UserConfig } from './config.ts'
+
+function parseFlags(...argv: string[]): UserConfig {
+  cli.parse(['node', 'tsdown', ...argv], { run: false })
+  return normalizeFlags(cli.options as UserConfig)
+}
+
+test('--deps.never-bundle maps to deps.neverBundle', () => {
+  expect(parseFlags('--deps.never-bundle', 'lodash').deps).toEqual({
+    neverBundle: 'lodash',
+  })
+})
+
+test('--deps.neverBundle keeps working', () => {
+  expect(parseFlags('--deps.neverBundle', 'lodash').deps).toEqual({
+    neverBundle: 'lodash',
+  })
+})
+
+test('--env.* keys are left verbatim', () => {
+  expect(parseFlags('--env.MY-VAR', 'a', '--env.other_var', 'b').env).toEqual({
+    'MY-VAR': 'a',
+    other_var: 'b',
+  })
+})

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/no-top-level-side-effects */
 import process from 'node:process'
-import { cac } from 'cac'
+import { cac, type CAC } from 'cac'
 import { VERSION as rolldownVersion } from 'rolldown'
 import { x } from 'tinyexec'
 import pkg from '../package.json' with { type: 'json' }
@@ -8,8 +8,34 @@ import { enableDebug } from './features/debug.ts'
 import { globalLogger } from './utils/logger.ts'
 import { styleText } from './utils/style.ts'
 import type { UserConfig } from './config.ts'
+import type { DepsConfig } from './features/deps.ts'
 
-const cli = cac('tsdown')
+/**
+ * cac camel-cases only the first segment of a dotted option name, so
+ * `--deps.never-bundle` is parsed into `{ deps: { 'never-bundle': ... } }` and
+ * never reaches {@linkcode DepsConfig.neverBundle | deps.neverBundle}.
+ *
+ * `--env.*` is deliberately left alone: its keys are user-defined environment
+ * variable names, not option names.
+ *
+ * **Internal API, not for public use**
+ * @private
+ */
+export function normalizeFlags(flags: UserConfig): UserConfig {
+  if (flags.deps && typeof flags.deps === 'object') {
+    flags.deps = Object.fromEntries(
+      Object.entries(flags.deps).map(([key, value]) => [
+        key.replaceAll(/([a-z])-([a-z])/g, (_, a: string, b: string) => {
+          return a + b.toUpperCase()
+        }),
+        value,
+      ]),
+    ) as DepsConfig
+  }
+  return flags
+}
+
+export const cli: CAC = cac('tsdown')
 cli.help().version(pkg.version)
 
 cli
@@ -91,7 +117,7 @@ cli
     )
     const { build } = await import('./build.ts')
     if (input.length > 0) flags.entry = input
-    await build(flags)
+    await build(normalizeFlags(flags))
   })
 
 cli


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
- [x] AI was used: Claude Code + Opus 5
  - [ ] I have carefully reviewed the AI-generated content myself.

### Description

`--deps.never-bundle` has been a no-op since the `deps` namespace rename (7f50966). cac's `camelcaseOptionName` camel-cases only the first segment of a dotted option name, so the flag parses to `deps['never-bundle']` while `resolveDepsConfig` reads `deps.neverBundle`. Nothing errors, because the command sets `allowUnknownOptions`.

On `main`, with `leftpad` present in `node_modules`:

```
tsdown --deps.never-bundle leftpad   # leftpad inlined into the bundle
tsdown --deps.neverBundle leftpad    # leftpad external
tsdown --external leftpad            # leftpad external (deprecated flag)
```

Renaming the option to `--deps.neverBundle` was the alternative. That leaves the kebab spelling silently doing nothing, and the kebab spelling is what `docs/reference/cli.md` and `skills/tsdown/references/` document, so this normalizes the parsed keys and both spellings work.

Normalization is scoped to `flags.deps` at one level. `--env.*` is excluded since its keys are user-supplied variable names. A future dotted option in another namespace would need the same handling.

`src/cli.test.ts` parses through the real `cli` instance, which required exporting it. The first case fails on `main`; the other two pin current behavior.

### Linked Issues

### Additional context
