### PR TITLE
feat: expose programmatic watch controls

### DIFF
--- a/__snapshots__/tsnapi/config.snapshot.d.ts
+++ b/__snapshots__/tsnapi/config.snapshot.d.ts
@@ -68,14 +68,16 @@ export interface UserConfig {
   external?: ExternalOption;
   noExternal?: Arrayable<string | RegExp> | NoExternalFn;
 }
+export interface UserConfigFnContext {
+  ci: boolean;
+  rootConfig?: UserConfig;
+  watch: TsdownHandle["watch"];
+}
 // #endregion
 
 // #region Types
 export type UserConfigExport = Awaitable<Arrayable<UserConfig> | UserConfigFn>;
-export type UserConfigFn = (_: InlineConfig, _: {
-  ci: boolean;
-  rootConfig?: UserConfig;
-}) => Awaitable<Arrayable<UserConfig>>;
+export type UserConfigFn = (_: InlineConfig, _: UserConfigFnContext) => Awaitable<Arrayable<UserConfig>>;
 // #endregion
 
 // #region Functions

--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -119,6 +119,13 @@ export interface TsdownBundle extends AsyncDisposable {
   config: ResolvedConfig;
   inlinedDeps: Map<string, Set<string>>;
 }
+export interface TsdownHandle {
+  bundles: TsdownBundle[];
+  watch: {
+    restart: () => Promise<TsdownHandle>;
+    close: () => Promise<void>;
+  };
+}
 export interface TsdownHooks {
   "build:prepare": (_: BuildContext) => void | Promise<void>;
   "build:before": (_: BuildContext & RolldownContext) => void | Promise<void>;
@@ -196,6 +203,11 @@ export interface UserConfig {
   external?: ExternalOption;
   noExternal?: Arrayable<string | RegExp> | NoExternalFn;
 }
+export interface UserConfigFnContext {
+  ci: boolean;
+  rootConfig?: UserConfig;
+  watch: TsdownHandle["watch"];
+}
 export interface Workspace {
   include?: "auto" | (string & {}) | string[];
   exclude?: Arrayable<string>;
@@ -252,18 +264,15 @@ export type TsdownPluginOption<A = any> = Awaitable<TsdownPlugin<A> | RolldownPl
 } | undefined | null | void | false | TsdownPluginOption<A>[]>;
 export type UnusedOptions = import("unplugin-unused").Options;
 export type UserConfigExport = Awaitable<Arrayable<UserConfig> | UserConfigFn>;
-export type UserConfigFn = (_: InlineConfig, _: {
-  ci: boolean;
-  rootConfig?: UserConfig;
-}) => Awaitable<Arrayable<UserConfig>>;
+export type UserConfigFn = (_: InlineConfig, _: UserConfigFnContext) => Awaitable<Arrayable<UserConfig>>;
 export type WithEnabled<T> = boolean | undefined | CIOption | (T & {
   enabled?: boolean | CIOption;
 });
 // #endregion
 
 // #region Functions
-export declare function build(_?: InlineConfig): Promise<TsdownBundle[]>;
-export declare function buildWithConfigs(_: ResolvedConfig[], _: Set<string>, _: () => void): Promise<TsdownBundle[]>;
+export declare function build(_?: InlineConfig): Promise<TsdownHandle>;
+export declare function buildWithConfigs(_: ResolvedConfig[], _: Set<string>, _: () => Promise<TsdownHandle>): Promise<TsdownHandle>;
 export declare function defineConfig(_: UserConfig): UserConfig;
 export declare function defineConfig(_: UserConfig[]): UserConfig[];
 export declare function defineConfig(_: UserConfigFn): UserConfigFn;

--- a/docs/advanced/programmatic-usage.md
+++ b/docs/advanced/programmatic-usage.md
@@ -24,7 +24,7 @@ bundle output to disk:
 ```ts twoslash
 import { build } from 'tsdown'
 
-const bundles = await build({
+const { bundles } = await build({
   entry: ['src/index.ts'],
   format: 'esm',
   write: false,
@@ -39,9 +39,12 @@ for (const bundle of bundles) {
 }
 ```
 
-`build()` currently returns a `TsdownBundle[]`, with one bundle for each
-resolved configuration. Even a single configuration returns an array; its
-in-memory Rolldown outputs are available in `bundle.chunks`.
+`build()` returns a `TsdownHandle`. Its `bundles` array contains one bundle for
+each resolved configuration. In watch mode, `watch.restart()` restarts the build
+and resolves to the new handle, while `watch.close()` gracefully closes all
+watchers. Each handle can only be restarted once. Even a single configuration
+produces an array; its in-memory Rolldown outputs are available in
+`bundle.chunks`.
 
 The `write` option controls Rolldown's bundle output, while other file operations
 are configured separately. For example, `clean` defaults to `true`, so set

--- a/docs/zh-CN/advanced/programmatic-usage.md
+++ b/docs/zh-CN/advanced/programmatic-usage.md
@@ -23,7 +23,7 @@ await build({
 ```ts twoslash
 import { build } from 'tsdown'
 
-const bundles = await build({
+const { bundles } = await build({
   entry: ['src/index.ts'],
   format: 'esm',
   write: false,
@@ -38,7 +38,7 @@ for (const bundle of bundles) {
 }
 ```
 
-`build()` 当前返回 `TsdownBundle[]`，每个解析后的配置对应一个 bundle。即使只有单个配置，返回值也是数组；内存中的 Rolldown 输出位于 `bundle.chunks`。
+`build()` 返回 `TsdownHandle`。其中 `bundles` 数组为每个解析后的配置包含一个 bundle。在监听模式下，`watch.restart()` 用于重启构建并返回新的 handle，`watch.close()` 会优雅地关闭所有 watcher。每个 handle 只能重启一次。即使只有单个配置，`bundles` 也是数组；内存中的 Rolldown 输出位于 `bundle.chunks`。
 
 `write` 选项控制 Rolldown 打包产物的写入，其他文件操作则单独配置。例如，`clean` 默认为 `true`，因此如果必须保留现有输出目录，请像上面的示例一样设置 `clean: false`。显式启用的 `copy` 或 `exports` 等功能仍可能写入文件。`write: false` 与监听模式不兼容。
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "^12.3.1",
+      "version": "12.3.1",
       "onFail": "download"
     }
   },

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "inlinedDependencies": {
     "package-manager-detector": "1.8.0",
-    "pkg-types": "2.3.1"
+    "pkg-types": "2.3.2"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:peer",

--- a/packages/migrate/tests/fixtures/monorepo/apps/pkg3/package.json
+++ b/packages/migrate/tests/fixtures/monorepo/apps/pkg3/package.json
@@ -7,6 +7,6 @@
     "build": "tsup src/index.ts"
   },
   "dependencies": {
-    "tsup": "^7.2.0"
+    "tsup": "^8.5.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: ^12.3.1
+        specifier: 12.3.1
         version: 12.3.1
 
 packages:

--- a/src/build.ts
+++ b/src/build.ts
@@ -133,7 +133,8 @@ export async function buildWithConfigs(
         isDualFormat,
         clean,
         () => {
-          if (!restarted) restart()
+          if (restarted) return
+          restart().catch((error) => globalLogger.error(error))
         },
         done,
       )
@@ -156,7 +157,10 @@ export async function buildWithConfigs(
     startDevtoolsUI(firstDevtoolsConfig.devtools)
   }
 
-  return { bundles, watch: { restart, close } }
+  return {
+    bundles,
+    watch: { restart, close },
+  }
 }
 
 /**

--- a/src/build.ts
+++ b/src/build.ts
@@ -29,6 +29,7 @@ import {
   addOutDirToChunks,
   type RolldownChunk,
   type TsdownBundle,
+  type TsdownHandle,
 } from './utils/chunks.ts'
 import { debounce, typeAssert } from './utils/general.ts'
 import { globalLogger } from './utils/logger.ts'
@@ -39,11 +40,37 @@ import { styleText } from './utils/style.ts'
  */
 export async function build(
   inlineConfig: InlineConfig = {},
-): Promise<TsdownBundle[]> {
+): Promise<TsdownHandle> {
   globalLogger.level = inlineConfig.logLevel || 'info'
-  const { configs, deps: configDeps } = await resolveConfig(inlineConfig)
 
-  return buildWithConfigs(configs, configDeps, () => build(inlineConfig))
+  let isConfigResolved = false
+  const { configs, deps } = await resolveConfig(inlineConfig, {
+    restart,
+    close,
+  })
+  const handlePromise = buildWithConfigs(configs, deps, () =>
+    build(inlineConfig),
+  )
+  isConfigResolved = true
+  return await handlePromise
+
+  async function restart() {
+    if (!isConfigResolved) {
+      throw new Error(
+        '`watch.restart` cannot be called before config resolution is complete.',
+      )
+    }
+    return (await handlePromise).watch.restart()
+  }
+
+  async function close() {
+    if (!isConfigResolved) {
+      throw new Error(
+        '`watch.close` cannot be called before config resolution is complete.',
+      )
+    }
+    return (await handlePromise).watch.close()
+  }
 }
 
 /**
@@ -55,8 +82,9 @@ export async function build(
 export async function buildWithConfigs(
   configs: ResolvedConfig[],
   configDeps: Set<string>,
-  _restart: () => void,
-): Promise<TsdownBundle[]> {
+  rebuild: () => Promise<TsdownHandle>,
+): Promise<TsdownHandle> {
+  const hasWatchConfig = configs.some((config) => config.watch)
   let cleanPromise: Promise<void> | undefined
   const clean = () => {
     if (cleanPromise) return cleanPromise
@@ -64,14 +92,27 @@ export async function buildWithConfigs(
   }
 
   const disposeCbs: Array<() => void | PromiseLike<void>> = []
-  let restarting = false
-  async function restart() {
-    if (restarting) return
-    restarting = true
+  let restarted = false
 
+  function assertWatchMode() {
+    if (!hasWatchConfig) {
+      throw new Error('`watch` is only available in watch mode.')
+    }
+  }
+  async function close() {
+    assertWatchMode()
     await Promise.all(disposeCbs.map((cb) => cb()))
+  }
+
+  async function restart() {
+    assertWatchMode()
+    if (restarted) {
+      throw new Error('`watch.restart` can only be called once per handle.')
+    }
+    restarted = true
+    await close()
     clearRequireCache()
-    _restart()
+    return rebuild()
   }
 
   const configChunksByPkg = initBundleByPkg(configs)
@@ -91,7 +132,9 @@ export async function buildWithConfigs(
         configDeps,
         isDualFormat,
         clean,
-        restart,
+        () => {
+          if (!restarted) restart()
+        },
         done,
       )
     }),
@@ -101,7 +144,6 @@ export async function buildWithConfigs(
     (config) => config.devtools && config.devtools.ui,
   )
 
-  const hasWatchConfig = configs.some((config) => config.watch)
   if (hasWatchConfig) {
     // Watch mode with shortcuts
     disposeCbs.push(shortcuts(restart))
@@ -114,7 +156,7 @@ export async function buildWithConfigs(
     startDevtoolsUI(firstDevtoolsConfig.devtools)
   }
 
-  return bundles
+  return { bundles, watch: { restart, close } }
 }
 
 /**
@@ -164,7 +206,7 @@ async function buildSingle(
   const configs = await initBuildOptions()
   if (watch) {
     watcher = rolldownWatch(configs)
-    handleWatcher(watcher)
+    await handleWatcher(watcher)
   } else {
     const outputs = await config.runBuild(() => rolldownBuild(configs))
     for (const { output } of outputs) {
@@ -183,6 +225,7 @@ async function buildSingle(
   return bundle
 
   function handleWatcher(watcher: RolldownWatcher) {
+    const ready = Promise.withResolvers<void>()
     const changedFile: string[] = []
     let hasError = false
 
@@ -226,6 +269,7 @@ async function buildSingle(
 
           chunks.length = 0
           hasError = false
+          ready.resolve()
           break
         }
 
@@ -261,6 +305,8 @@ async function buildSingle(
         }
       }
     })
+
+    return ready.promise
   }
 
   async function initBuildOptions() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import type {
   UserConfig,
   UserConfigExport,
   UserConfigFn,
+  UserConfigFnContext,
 } from './config/index.ts'
 /**
  * Defines the configuration for tsdown.
@@ -14,5 +15,5 @@ export function defineConfig(options: UserConfigExport): UserConfigExport {
   return options
 }
 
-export type { UserConfig, UserConfigExport, UserConfigFn }
+export type { UserConfig, UserConfigExport, UserConfigFn, UserConfigFnContext }
 export { mergeConfig } from './config/options.ts'

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -5,12 +5,16 @@ import { pathToFileURL } from 'node:url'
 import { depsStore, init, isSupported } from 'import-without-cache'
 import { createDebug } from 'obug'
 import { createConfigCoreLoader } from 'unconfig-core'
-import { isInCI } from '../utils/ci.ts'
 import { fsStat } from '../utils/fs.ts'
 import { importWithError, toArray } from '../utils/general.ts'
 import { globalLogger } from '../utils/logger.ts'
 import { styleText } from '../utils/style.ts'
-import type { InlineConfig, UserConfig, UserConfigExport } from './types.ts'
+import type {
+  InlineConfig,
+  UserConfig,
+  UserConfigExport,
+  UserConfigFnContext,
+} from './types.ts'
 import type {
   ConfigEnv,
   UserConfig as ViteUserConfig,
@@ -65,8 +69,8 @@ const configPrefix = 'tsdown.config'
 
 export async function loadConfigFile(
   inlineConfig: InlineConfig,
+  context: UserConfigFnContext,
   workspace?: string,
-  rootConfig?: UserConfig,
 ): Promise<{
   configs: UserConfig[]
   deps?: Set<string>
@@ -136,7 +140,7 @@ export async function loadConfigFile(
 
     exported = await exported
     if (typeof exported === 'function') {
-      exported = await exported(inlineConfig, { ci: isInCI(), rootConfig })
+      exported = await exported(inlineConfig, context)
     }
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,11 +1,16 @@
 import path from 'node:path'
 import { createDebug } from 'obug'
+import { isInCI } from '../utils/ci.ts'
 import { createConcurrencyExecutor } from '../utils/general.ts'
 import { globalLogger } from '../utils/logger.ts'
 import { loadConfigFile } from './file.ts'
 import { resolveUserConfig } from './options.ts'
 import { resolveWorkspace } from './workspace.ts'
-import type { InlineConfig, ResolvedConfig } from './types.ts'
+import type {
+  InlineConfig,
+  ResolvedConfig,
+  UserConfigFnContext,
+} from './types.ts'
 
 export * from './types.ts'
 
@@ -19,7 +24,10 @@ const debug = createDebug('tsdown:config')
 
 // resolved configs count = 1 (inline config) * root config count * workspace count * sub config count
 
-export async function resolveConfig(inlineConfig: InlineConfig): Promise<{
+export async function resolveConfig(
+  inlineConfig: InlineConfig,
+  watch: UserConfigFnContext['watch'],
+): Promise<{
   configs: ResolvedConfig[]
   deps: Set<string>
 }> {
@@ -29,8 +37,14 @@ export async function resolveConfig(inlineConfig: InlineConfig): Promise<{
     inlineConfig.cwd = path.resolve(inlineConfig.cwd)
   }
 
-  const { configs: rootConfigs, deps: rootDeps } =
-    await loadConfigFile(inlineConfig)
+  const context: UserConfigFnContext = {
+    ci: isInCI(),
+    watch,
+  }
+  const { configs: rootConfigs, deps: rootDeps } = await loadConfigFile(
+    inlineConfig,
+    context,
+  )
   const globalDeps = new Set<string>(rootDeps)
   const runBuild = createConcurrencyExecutor(inlineConfig.concurrency)
 
@@ -38,7 +52,7 @@ export async function resolveConfig(inlineConfig: InlineConfig): Promise<{
     await Promise.all(
       rootConfigs.map(async (rootConfig): Promise<ResolvedConfig[]> => {
         const { configs: workspaceConfigs, deps: workspaceDeps } =
-          await resolveWorkspace(rootConfig, inlineConfig, rootDeps)
+          await resolveWorkspace(rootConfig, inlineConfig, context, rootDeps)
         debug('workspace configs %O', workspaceConfigs)
 
         const configs = (

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -24,7 +24,11 @@ import type { ExportsOptions } from '../features/pkg/exports.ts'
 import type { PublintOptions } from '../features/pkg/publint.ts'
 import type { TsdownPlugin, TsdownPluginOption } from '../features/plugin.ts'
 import type { ReportOptions } from '../features/report.ts'
-import type { RolldownChunk, TsdownBundle } from '../utils/chunks.ts'
+import type {
+  RolldownChunk,
+  TsdownBundle,
+  TsdownHandle,
+} from '../utils/chunks.ts'
 import type { ConcurrencyExecutor } from '../utils/general.ts'
 import type { Logger, LogLevel } from '../utils/logger.ts'
 import type { PackageJsonWithPath, PackageType } from '../utils/package.ts'
@@ -104,6 +108,7 @@ export type {
   SeaConfig,
   TreeshakingOptions,
   TsdownBundle,
+  TsdownHandle,
   TsdownHooks,
   TsdownPlugin,
   TsdownPluginOption,
@@ -676,9 +681,15 @@ export interface InlineConfig extends UserConfig {
   concurrency?: number
 }
 
+export interface UserConfigFnContext {
+  ci: boolean
+  rootConfig?: UserConfig
+  watch: TsdownHandle['watch']
+}
+
 export type UserConfigFn = (
   inlineConfig: InlineConfig,
-  context: { ci: boolean; rootConfig?: UserConfig },
+  context: UserConfigFnContext,
 ) => Awaitable<Arrayable<UserConfig>>
 
 export type UserConfigExport = Awaitable<Arrayable<UserConfig> | UserConfigFn>

--- a/src/config/workspace.ts
+++ b/src/config/workspace.ts
@@ -5,7 +5,7 @@ import { glob } from 'tinyglobby'
 import { slash } from '../utils/general.ts'
 import { loadConfigFile } from './file.ts'
 import { mergeConfig } from './options.ts'
-import type { InlineConfig, UserConfig } from './types.ts'
+import type { InlineConfig, UserConfig, UserConfigFnContext } from './types.ts'
 
 const debug = createDebug('tsdown:config:workspace')
 
@@ -19,6 +19,7 @@ const DEFAULT_EXCLUDE_WORKSPACE = [
 export async function resolveWorkspace(
   config: UserConfig,
   inlineConfig: InlineConfig,
+  context: UserConfigFnContext,
   rootDeps?: Set<string>,
 ): Promise<{ configs: UserConfig[]; deps: Set<string> }> {
   const normalized = mergeConfig(config, inlineConfig)
@@ -70,6 +71,7 @@ export async function resolveWorkspace(
     throw new Error('No workspace packages found, please check your config')
   }
 
+  context = { ...context, rootConfig: normalized }
   const configs = (
     await Promise.all(
       packages.map(async (cwd) => {
@@ -80,8 +82,8 @@ export async function resolveWorkspace(
             config: workspaceConfig,
             cwd,
           },
+          context,
           cwd,
-          normalized,
         )
         workspaceDeps?.forEach((dep) => deps.add(dep))
         return configs.map((config) => mergeConfig(normalized, config))

--- a/src/features/plugin.test.ts
+++ b/src/features/plugin.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test, vi } from 'vitest'
 import { chdir, writeFixtures } from '../../tests/utils.ts'
-import { resolveConfig } from '../config/index.ts'
+import {
+  resolveConfig as _resolveConfig,
+  type InlineConfig,
+} from '../config/index.ts'
 import { flattenPlugins, type TsdownPlugin } from './plugin.ts'
 import type { Plugin } from 'rolldown'
+
+const watch = {
+  restart: () => Promise.reject(),
+  close: () => Promise.reject(),
+}
+const resolveConfig = (config: InlineConfig) => _resolveConfig(config, watch)
 
 describe('flattenPlugins', () => {
   test('flattens nested arrays', async () => {

--- a/src/features/shortcuts.ts
+++ b/src/features/shortcuts.ts
@@ -8,10 +8,10 @@ import { styleText } from '../utils/style.ts'
 export interface Shortcut {
   key: string
   description: string
-  action: () => void | Promise<void>
+  action: () => void | Promise<unknown>
 }
 
-export function shortcuts(restart: () => void): () => void {
+export function shortcuts(restart: () => Promise<unknown>): () => void {
   let actionRunning = false
   async function onInput(input: string) {
     if (actionRunning) return
@@ -20,9 +20,7 @@ export function shortcuts(restart: () => void): () => void {
       {
         key: 'r',
         description: 'reload config and rebuild',
-        action() {
-          restart()
-        },
+        action: restart,
       },
       {
         key: 'c',

--- a/src/utils/chunks.ts
+++ b/src/utils/chunks.ts
@@ -9,6 +9,13 @@ export interface TsdownBundle extends AsyncDisposable {
   config: ResolvedConfig
   inlinedDeps: Map<string, Set<string>>
 }
+export interface TsdownHandle {
+  bundles: TsdownBundle[]
+  watch: {
+    restart: () => Promise<TsdownHandle>
+    close: () => Promise<void>
+  }
+}
 
 export function addOutDirToChunks(
   chunks: Array<OutputChunk | OutputAsset>,

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { RE_NODE_MODULES } from 'rolldown-plugin-dts/internal'
 import { describe, expect, test, vi } from 'vitest'
 import {
-  resolveConfig,
+  resolveConfig as _resolveConfig,
   type InlineConfig,
   type UserConfig,
 } from '../src/config/index.ts'
@@ -11,6 +11,12 @@ import { slash } from '../src/utils/general.ts'
 import { globalLogger } from '../src/utils/logger.ts'
 import { chdir, testBuild, writeFixtures } from './utils.ts'
 import type { Plugin } from 'rolldown'
+
+const watch = {
+  restart: () => Promise.reject(),
+  close: () => Promise.reject(),
+}
+const resolveConfig = (config: InlineConfig) => _resolveConfig(config, watch)
 
 const pluginMockDepCode: Plugin = {
   name: 'mock-dep-code',

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -7,7 +7,7 @@ import { format } from 'prettier'
 import { glob } from 'tinyglobby'
 import { mergeUserOptions } from '../src/config/options.ts'
 import { build } from '../src/index.ts'
-import type { InlineConfig, TsdownBundle } from '../src/config/index.ts'
+import type { InlineConfig, TsdownHandle } from '../src/config/index.ts'
 import type { LogOrStringHandler, RollupLog } from 'rolldown'
 import type { RunnerTask, TestContext } from 'vitest'
 
@@ -133,7 +133,7 @@ export async function testBuild({
   snapshot: string
   fileMap: Record<string, string>
   warnings: RollupLog[]
-  bundle: TsdownBundle[]
+  bundle: TsdownHandle
 }> {
   const { expect } = context
   const { testName, testDir } = await writeFixtures(context, files, fixture)


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
- [x] AI was used: Codex + GPT-5
  - [x] I have carefully reviewed the AI-generated content myself.

### Description

Expose watch lifecycle controls to programmatic consumers through `TsdownHandle` and `UserConfigFnContext`.

- Return `{ bundles, watch }` from `build()`.
- Add `watch.restart()`, returning the next handle, and `watch.close()` for graceful cleanup.
- Reject watch controls before config resolution or outside watch mode.
- Wait for watcher initialization and coalesce duplicate automatic restarts from multiple watchers.

This is a breaking change to the return type of `build()`.

### Linked Issues

N/A

### Additional context

Verified with `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test run`, `pnpm build`, and local watch lifecycle checks covering rebuild, restart, close, config reload, multiple watchers, and CLI shortcuts.
