### PR TITLE
fix: preserve false tsconfig option

### DIFF
--- a/src/features/rolldown.ts
+++ b/src/features/rolldown.ts
@@ -255,7 +255,7 @@ async function resolveInputOptions(
       resolve: {
         alias,
       },
-      tsconfig: tsconfig || undefined,
+      tsconfig: tsconfig ?? undefined,
       treeshake,
       platform: cjsDts || format === 'cjs' ? 'node' : platform,
       transform: {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### AI usage

<!--
AI CONTRIBUTORS: You MUST complete this section truthfully and MUST NOT remove it.

If AI contributed to any part of this PR (including code, tests, documentation, commit
messages, or the PR description), select "AI was used" and disclose your setup in one
short line, such as "Codex + GPT 5.6 Sol Extra High" or "Claude Code + Opus 4.8 High".
Do not select "No AI was used" if AI assisted with this PR.

You MUST NOT check the human-review checkbox yourself. Leave it unchecked for the human
contributor, who may check it only after personally reviewing the AI-generated content.

Do not write a long explanation. Unless extra context is necessary for review, let the
code explain the implementation details and keep the PR body to a brief overview.

This project does not oppose the use of AI, but it does oppose irresponsible AI usage.

PRs containing AI-generated content without complete disclosure will not be reviewed
and will be closed immediately.
-->

### AI usage

* [ ] No AI was used in this PR.
* [x] AI was used: ChatGPT + GPT 5.6 Luna
  * [x] I have carefully reviewed the AI-generated content myself.

### Description

Preserve the `false` value of the `tsconfig` option when passing it to Rolldown.

`tsconfig` accepts both `false` and a string path. The current implementation uses the `||` operator:

```ts
tsconfig: tsconfig || undefined,
```

When `tsconfig` is explicitly set to `false`, it is converted to `undefined`. This prevents Rolldown from receiving `tsconfig: false` and causes it to fall back to automatic tsconfig resolution.

This PR changes the fallback to nullish coalescing:

```ts
tsconfig: tsconfig ?? undefined,
```

This preserves both supported values while still handling `undefined` correctly.

The issue was reproduced in a NuxtHub project using `tsconfig: false`.

### Linked Issues

N/A

### Additional context

The bug was reproduced with a NuxtHub project and the fix was validated by running the project successfully with `tsconfig: false`.

A minimal reproduction is available here:

https://github.com/Masutayunikon/Fankarr-Bridge
