### PR TITLE
fix(entry): include cwd in "Cannot find entry" error

### DIFF
--- a/src/features/entry.test.ts
+++ b/src/features/entry.test.ts
@@ -1,7 +1,9 @@
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { writeFixtures } from '../../tests/utils.ts'
-import { toObjectEntry } from './entry.ts'
+import { createLogger } from '../utils/logger.ts'
+import { styleText } from '../utils/style.ts'
+import { resolveEntry, toObjectEntry } from './entry.ts'
 
 describe('toObjectEntry', () => {
   test('string entry', async (context) => {
@@ -249,5 +251,17 @@ describe('toObjectEntry', () => {
       'src/index': path.join(testDir, 'src/index.ts'),
       'src/utils/helper': path.join(testDir, 'src/utils/helper.ts'),
     })
+  })
+})
+
+describe('resolveEntry', () => {
+  // #1067
+  test('unmatched entry error includes the cwd', async (context) => {
+    const { testDir } = await writeFixtures(context, {
+      'src/index.ts': '',
+    })
+    await expect(
+      resolveEntry(createLogger(), ['src/*.js'], testDir, styleText),
+    ).rejects.toThrow(`Cannot find entry: ["src/*.js"] in ${testDir}`)
   })
 })

--- a/src/features/entry.ts
+++ b/src/features/entry.ts
@@ -31,7 +31,9 @@ export async function resolveEntry(
   const [entryMap, computedRoot] = await toObjectEntry(entry, cwd, root)
   const entries = Object.values(entryMap)
   if (entries.length === 0) {
-    throw new Error(`${nameLabel} Cannot find entry: ${JSON.stringify(entry)}`)
+    throw new Error(
+      `${nameLabel} Cannot find entry: ${JSON.stringify(entry)} in ${cwd}`,
+    )
   }
   logger.info(
     nameLabel,


### PR DESCRIPTION
### AI usage

- [ ] No AI was used in this PR.
- [ ] AI was used: <!-- e.g. Codex + GPT 5.6 Sol Extra High -->
  - [ ] I have carefully reviewed the AI-generated content myself.

### Description

When a `workspace` include glob matches a directory with no `package.json` and no config of its own, tsdown still builds that directory with the merged root config, so it inherits the root `entry` and the root `name`. Entry resolution matches nothing there and the build fails with `[root-name] Cannot find entry: [...]`. That message points at the root package and carries no path, so working out which directory actually broke the build takes a while in a large monorepo.

The error now ends with the resolved `cwd`, which names the offending directory.

### Linked Issues

Fixes #1067

### Additional context

The new unit test fails on `main` and passes here.
